### PR TITLE
Do not regenerate genesis.json if action=update.

### DIFF
--- a/qube-init
+++ b/qube-init
@@ -25,8 +25,6 @@ end.parse!
 
 @action_flag=options[:action]
 
-puts "using action flag : " + @action_flag
-
 # setup the config file to use to generate the quorum resources and kubernetes API resources.
 @config_file = "qubernetes.yaml"
 @optional_config_file=ARGV[0]

--- a/quorum-config
+++ b/quorum-config
@@ -2,6 +2,26 @@
 
 require "yaml"
 require "erb"
+require 'optparse'
+
+# set up flag options
+options = {action: 'ask'}
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: ./quorum-config [options]"
+
+  opts.on("-a", "--action [ACTION]", String,
+          "create: generate all new resources.
+                                     update: do not regenerate the genesis.json.") do |a|
+    options[:action] = a
+  end
+
+  opts.on("-h", "--help", "prints this help.") do
+    puts opts
+    exit
+  end
+
+end.parse!
 
 def set_node_template_vars(values)
   @Node_UserIdent        = values["Node_UserIdent"]
@@ -29,6 +49,13 @@ if @optional_config_file != nil
 end
 puts "using config file: " + @config_file
 
+# decide to create new resources
+action = options[:action]
+generateGenesis=true
+if (action == 'update')
+  generateGenesis=false
+end
+
 @config     = YAML.load_file(@config_file)
 @nodes      = @config["nodes"] #YAML.load_file("nodes.yaml")["nodes"]
 
@@ -51,6 +78,8 @@ end
 if @config.dig("config","Genesis_File")
   @Genesis_File = @config["config"]["Genesis_File"]
 end
+
+@Istanbul_Validator_Config = @Key_Dir_Base + "/istanbul-validator-config.toml"
 
 @Chain_Id=1101
 if @config.dig("config","Chain_Id")
@@ -96,11 +125,18 @@ end
 @base_template_path = "templates/quorum"
 `mkdir -p out/config`
 
+
+puts(@Istanbul_Validator_Config)
+File.open(@Istanbul_Validator_Config , "w") do |f|
+  f.puts (ERB.new(File.read(@base_template_path + "/istanbul-validator.toml.erb"), nil, "-").result)
+end
+
 # create genesis files with all discovered keystore accounts pre alloc with funds.
-puts(@Genesis_File)
-File.open(@Genesis_File, "w") do |f|
-  #f.puts (ERB.new(File.read(@base_template_path + "/genesis.json.erb"), nil, "-").result(binding))
-  f.puts (ERB.new(File.read(@base_template_path + "/genesis.json.erb"), nil, "-").result)
+if generateGenesis
+  puts(@Genesis_File)
+  File.open(@Genesis_File, "w") do |f|
+    f.puts (ERB.new(File.read(@base_template_path + "/genesis.json.erb"), nil, "-").result)
+  end
 end
 
 # create permission nodes file containing all the nodes.

--- a/quorum-init
+++ b/quorum-init
@@ -68,7 +68,7 @@ end
 
 # delete out directory if creating new
 if createNew
-    `rm -r out`
+    `rm -r -f out`
 end
 
 `
@@ -95,7 +95,7 @@ puts "  Generating Quorum configs..."
 # generate the appropriate config files:
 #   permissioned-nodes.json
 #   genesis.json
-./quorum-config #{@config_file}
+./quorum-config #{@config_file} --action=#{action}
 `
 
 puts ""

--- a/templates/quorum/genesis.json.erb
+++ b/templates/quorum/genesis.json.erb
@@ -157,32 +157,7 @@ end
    # is then given as input to the istanbul tool, which will calculate the necessary extradata field.
   %>
   <%-
-  @IstanbulConfig = @Key_Dir_Base + "/istanbul-validator-config.toml"
-  File.open(@IstanbulConfig, "w") do |f|
-    f.puts ("vanity = \"0x00\" \nvalidators = [")
-  end
-
- @nodes.each do |node|
-   set_node_template_vars(node)
-   #puts(@Key_Dir_Base + "/" + @Node_Key_Dir + "/nodekey")
-   File.open(@Key_Dir_Base + "/" + @Node_Key_Dir + "/nodekey", "r") do |f|
-    f.each_line do |nodekey|
-      nodeAcct=`ethkey generate tmpkey.json --passwordfile #{@Key_Dir_Base}/#{@Node_Key_Dir}/password.txt --privatekey #{@Key_Dir_Base}/#{@Node_Key_Dir}/nodekey | sed 's/Address: //g' | sed 's/}//g'`
-      `rm tmpkey.json`
-
-      puts("node account for Istanbul is: " + nodeAcct)
-
-      nodeAcct=nodeAcct.strip
-      File.open(@IstanbulConfig, "a") do |f|
-        f.puts "\"" + nodeAcct + "\","
-      end
-    end
-   end
-  end
-  File.open(@IstanbulConfig, "a") do |f|
-     f.puts "]"
-  end
-   extraData=`istanbul extra encode --config #{@IstanbulConfig} | awk '{print $4}'`
+   extraData=`istanbul extra encode --config #{@Istanbul_Validator_Config} | awk '{print $4}'`
    extraData=extraData.strip
    puts("Generated istanbul \"extraData\"=\"" + extraData + "\"")
    -%>

--- a/templates/quorum/istanbul-validator.toml.erb
+++ b/templates/quorum/istanbul-validator.toml.erb
@@ -1,0 +1,28 @@
+<%-
+  def set_node_template_vars(values)
+    @Node_UserIdent        = values["Node_UserIdent"]
+    @Node_Key_Dir          = values["Key_Dir"]
+    return
+  end
+-%>
+vanity = "0x00"
+validators = [
+<%-
+  @nodes.each do |node|
+    set_node_template_vars(node)
+    puts(@Key_Dir_Base + "/" + @Node_Key_Dir + "/nodekey")
+    File.open(@Key_Dir_Base + "/" + @Node_Key_Dir + "/nodekey", "r") do |f|
+       f.each_line do |nodekey|
+         nodeAcct=`ethkey generate tmpkey.json --passwordfile #{@Key_Dir_Base}/#{@Node_Key_Dir}/password.txt --privatekey #{@Key_Dir_Base}/#{@Node_Key_Dir}/nodekey | sed 's/Address: //g' | sed 's/}//g'`
+         `rm tmpkey.json`
+
+          puts("node account for Istanbul is: " + nodeAcct)
+
+         nodeAcct=nodeAcct.strip -%>
+"<%=nodeAcct%>",
+<%-
+       end
+    end
+  end
+-%>
+]


### PR DESCRIPTION
* Allow ./quorum-config to accept the --action=update flag, if the
action is update, do not regenerate the genesis.json, as the
genesis.json should only be create when initializing a new network.
* Move istanbul-validator.toml to its own generator file, instead of creating 
it inside the genesis generator.