### PR TITLE
Allow docker full repo & image setting.

### DIFF
--- a/qubernetes
+++ b/qubernetes
@@ -46,7 +46,11 @@ def set_node_template_vars(values)
   if values.dig("quorum","quorum", "Docker_Repo")
     @Quorum_Docker_Repo = values["quorum"]["quorum"]["Docker_Repo"]
   end
-
+  # Allow the user to set the full repo, e.g. quorum-local, e.g. the case they are using skaffold, or other local dev.
+  @Quorum_Docker_Repo_Full = ""
+  if values.dig("quorum","quorum", "Docker_Repo_Full")
+    @Quorum_Docker_Repo_Full = values["quorum"]["quorum"]["Docker_Repo_Full"]
+  end
 # default quorumengineering/quorum
   @Tm_Docker_Repo =  "quorumengineering"
   if values.dig("quorum","tm","Docker_Repo")

--- a/templates/k8s/quorum-deployment.yaml.erb
+++ b/templates/k8s/quorum-deployment.yaml.erb
@@ -46,7 +46,12 @@ spec:
       <%- end -%>
       initContainers:
       - name: quorum-genesis-init-container
+        <%- if @Quorum_Docker_Repo_Full != "" -%>
+        image: <%= @Quorum_Docker_Repo_Full %>
+        imagePullPolicy: Never
+        <%- else -%>
         image: <%= @Quorum_Docker_Repo %>/quorum:<%= @Quorum_Version %>
+        <%- end -%>
         command: [ "sh" ]
         args:
         - "-cx"
@@ -168,7 +173,12 @@ spec:
           subPath: tessera-config-9.0.json.tmpl
         <%- end -%>
       - name: quorum
+        <%- if @Quorum_Docker_Repo_Full != "" -%>
+        image: <%= @Quorum_Docker_Repo_Full %>
+        imagePullPolicy: Never
+        <%- else -%>
         image: <%= @Quorum_Docker_Repo %>/quorum:<%= @Quorum_Version %>
+        <%- end -%>
         readinessProbe:
           exec:
             command:


### PR DESCRIPTION
Allow for setting the full repo + name of the quorum image. This is
useful for local dev, e.g. skaffold.
Set `Docker_Repo_Full` in the node config.