### PR TITLE
Add qctl support for basic contract test.

### DIFF
--- a/qctl/qctl.go
+++ b/qctl/qctl.go
@@ -32,6 +32,13 @@ func main() {
 		//TODO: should init not take a parameter? what else would you init besides a config?
 		&initConfigCommand,
 		{
+			Name:  "test",
+			Usage: "run tests against the running network",
+			Subcommands: []*cli.Command{
+				&testContractCmd,
+			},
+		},
+		{
 			Name:  "generate",
 			Usage: "options for generating base config / resources",
 			Subcommands: []*cli.Command{
@@ -86,8 +93,8 @@ func main() {
 		},
 
 		{
-			Name:    "add",
-			Usage:   "options for adding resources",
+			Name:  "add",
+			Usage: "options for adding resources",
 			Subcommands: []*cli.Command{
 				&nodeAddCommand,
 			},

--- a/qctl/testcmd.go
+++ b/qctl/testcmd.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"github.com/urfave/cli/v2"
+	"os/exec"
+)
+
+var (
+	// qctl test contract --private node1
+	testContractCmd = cli.Command{
+		Name:  "contract",
+		Usage: "deploy the test contract(s) on a node.",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "both",
+				Usage: "try to deploy a public and private test contract to the node.",
+				Value: true,
+			},
+			&cli.BoolFlag{
+				Name:    "private",
+				Aliases: []string{"priv"},
+				Usage:   "try to deploy a private test contract to the node.",
+			},
+			&cli.BoolFlag{
+				Name:    "public",
+				Aliases: []string{"pub"},
+				Usage:   "try to deploy a public test contract to the node.",
+			},
+		},
+		Action: func(c *cli.Context) error {
+
+			if c.Args().Len() < 1 {
+				c.App.Run([]string{"test", "help", "contract"})
+				return cli.Exit("wrong number of arguments", 2)
+			}
+			nodeName := c.Args().First()
+			namespace := ""
+			podName := podNameFromPrefix(nodeName, namespace)
+			fmt.Println(fmt.Sprintf("running test contract(s) on node [%s] pod [%s]", nodeName, podName))
+
+			isBothTest := c.Bool("both")
+			isPrivTest := c.Bool("private")
+			isPublicTest := c.Bool("public")
+
+			// if either of the specific priv or pub flags are set, only run the specified flags.
+			if isPrivTest || isPublicTest {
+				isBothTest = false
+			}
+			var cmd *exec.Cmd
+			// test private tx
+			if isPrivTest || isBothTest {
+				fmt.Println()
+				green.Println("  Trying to deploy the test private contract...")
+				cmd = exec.Command("kubectl", "--namespace="+namespace, "exec", "-it", podName, "-c", "quorum", "--", "/etc/quorum/qdata/contracts/runscript.sh", "/etc/quorum/qdata/contracts/private_contract.js")
+				dropIntoCmd(cmd)
+			}
+
+			// test public tx
+			if isPublicTest || isBothTest {
+				fmt.Println()
+				green.Println("  Trying to deploy the test public contract...")
+				cmd = exec.Command("kubectl", "--namespace="+namespace, "exec", "-it", podName, "-c", "quorum", "--", "/etc/quorum/qdata/contracts/runscript.sh", "/etc/quorum/qdata/contracts/public_contract.js")
+				dropIntoCmd(cmd)
+			}
+
+			return nil
+		},
+	}
+
+	// TODO: support acceptance tests
+)


### PR DESCRIPTION
* add support to `qctl` to run test contract, e.g. as in
`helpers/run_contract.sh`, runs the test contract (private | public) that
is setup on the node.

`qctl test contract quorum-node1`