### PR TITLE
[qctl] add geth prometheus support.

### DIFF
--- a/qctl/configcmd.go
+++ b/qctl/configcmd.go
@@ -61,6 +61,11 @@ var (
 				Name:  "gethparams",
 				Usage: "additional geth startup params to run on the node.",
 			},
+			&cli.BoolFlag{
+				Name:  "monitor",
+				Usage: "enable monitoring on the geth / quorum node (prometheus).",
+				Value: false,
+			},
 		},
 
 		Action: func(c *cli.Context) error {
@@ -86,9 +91,9 @@ var (
 			chainId := c.String("chainid")
 			qimagefull := c.String("qimagefull")
 			gethparams := c.String("gethparams")
+			isMonitoring := c.Bool("monitor")
 
-			configYaml := GetYamlConfig()
-
+			configYaml := QConfig{}
 			for i := 1; i <= numberNodes; i++ {
 				quorum := Quorum{
 					Consensus:      consensus,
@@ -120,7 +125,11 @@ var (
 			configYaml.Genesis.Consensus = consensus
 			configYaml.Genesis.Chain_Id = chainId
 
-			//fmt.Println(config.ToString())
+			if isMonitoring {
+				//configYaml.Prometheus.NodePort = DefaultPrometheusNodePort
+				configYaml.Prometheus.Enabled = true
+			}
+			//fmt.Println(configYaml.ToString())
 			configBytes := []byte(configYaml.ToString())
 
 			// write the generated file out to disk this file will be used to initialize the network.

--- a/qctl/configyaml.go
+++ b/qctl/configyaml.go
@@ -45,12 +45,19 @@ type NodeEntry struct {
 	GethEntry     GethEntry   `yaml:"geth"`
 }
 
+type Prometheus struct {
+	//#monitor_params_geth: --metrics --metrics.expensive --pprof --pprofaddr=0.0.0.0
+	//monitorParamsGeth string `yaml:"monitor_params_geth"`
+	NodePort string `yaml:"nodePort_prom,omitempty"`
+	Enabled  bool   `yaml:"enabled,omitempty"`
+}
 type QConfig struct {
 	Genesis struct {
 		Consensus     string `yaml:"consensus"`
 		QuorumVersion string `yaml:"Quorum_Version"`
 		Chain_Id      string `yaml:"Chain_Id"`
 	}
+	Prometheus Prometheus `yaml:"prometheus,omitempty"`
 
 	Nodes []NodeEntry
 }

--- a/qctl/srvcmd.go
+++ b/qctl/srvcmd.go
@@ -42,6 +42,10 @@ var (
 				serviceNames := serviceNamesFromPrefix(nodeName, namespace, false)
 				for _, serviceName := range serviceNames {
 					nodeServiceInfo := serviceInfoForNode(serviceName, urlType, namespace)
+					if strings.Contains(serviceName, "monitor") { // monitor only support nodeport
+						fmt.Println(" prometheus server - " + nodeIp + ":" + nodeServiceInfo.NodePortPrometheus)
+						break
+					}
 					if urlType == "nodeport" {
 						if nodeServiceInfo.NodePortCakeshop != "" {
 							fmt.Println("cakeshop - " + nodeIp + ":" + nodeServiceInfo.NodePortCakeshop)
@@ -73,9 +77,10 @@ type NodeServiceInfo struct {
 	ClusterIPTmURL       string
 	ClusterIPCakeshopURL string
 
-	NodePortGeth     string
-	NodePortTm       string
-	NodePortCakeshop string
+	NodePortGeth       string
+	NodePortTm         string
+	NodePortCakeshop   string
+	NodePortPrometheus string
 }
 
 func serviceInfoForNode(nodeName, urlType, namespace string) NodeServiceInfo {
@@ -85,6 +90,10 @@ func serviceInfoForNode(nodeName, urlType, namespace string) NodeServiceInfo {
 	for _, serviceName := range serviceNames {
 		serviceName = strings.TrimSpace(serviceName)
 		srvOut := serviceForPrefix(serviceName, namespace, false)
+		if strings.Contains(serviceName, "monitor") { // only support nodeport
+			nodePortProm := nodePortFormClusterPort(srvOut, DefaultPrometheusClusterPort)
+			nodeServiceInfo.NodePortPrometheus = nodePortProm
+		}
 		// NodePort will display the geth and tessera node ports for the specified node(s)
 		// the nodePort can be accessed via the %Node_IP%:NodePort, the $NodeIP must be obtained
 		// by the user, or outside this cli as various K8s have different ways of obtaining the $NodeIP, e.g.

--- a/qctl/utils.go
+++ b/qctl/utils.go
@@ -27,6 +27,9 @@ var (
 	DefaultGethPort    = "8545"
 	DefaultTesseraPort = "9080"
 
+	DefaultPrometheusClusterPort = "9090"
+	DefaultPrometheusNodePort    = "31323"
+
 	ServiceTypeNodePort  = "nodeport"
 	ServiceTypeClusterIP = "clusterip"
 


### PR DESCRIPTION
* `qctl init --monitor` to enable prometheus support for geth / quorum.