### PR TITLE
[qctl] support deleting a node.

### DIFF
--- a/qctl/qctl.go
+++ b/qctl/qctl.go
@@ -52,7 +52,7 @@ func main() {
 			Subcommands: []*cli.Command{
 				&networkDeleteCommand,
 				// TODO: Think this through a bit, hard delete vs soft delete, etc.
-				//&nodeDeleteCommand,
+				&nodeDeleteCommand,
 			},
 		},
 		{


### PR DESCRIPTION
When deleting a node, remove the associated k8s deployment, pvc,  and service. If the
`--hard` flag is set, remove the associated keys and configs for the
node. `qctl delete node` always removes the node from the config
file.
* `qctl delete node  NODENAME``
* `qctl delete node --hard NODENAME`` // also remove the associated
keys.