### PR TITLE
[qctl] add `qctl stop node NODE_NAME`.

### DIFF
--- a/qctl/qctl.go
+++ b/qctl/qctl.go
@@ -56,6 +56,13 @@ func main() {
 			},
 		},
 		{
+			Name:  "stop",
+			Usage: "options for stopping nodes.",
+			Subcommands: []*cli.Command{
+				&nodeStopCommand,
+			},
+		},
+		{
 			Name:  "update",
 			Usage: "options for updating nodes / resources",
 			Subcommands: []*cli.Command{

--- a/qctl/testcmd.go
+++ b/qctl/testcmd.go
@@ -9,8 +9,9 @@ import (
 var (
 	// qctl test contract --private node1
 	testContractCmd = cli.Command{
-		Name:  "contract",
-		Usage: "deploy the test contract(s) on a node.",
+		Name:    "contract",
+		Aliases: []string{"contracts"},
+		Usage:   "deploy the test contract(s) on a node.",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "both",


### PR DESCRIPTION
Stopping a node will remove the node from the running K8s deployment,
but will not remove any other K8s resources or on disk resources, e.g.
the persisted state will be kept (PVC), as well as the keys, etc.

To "restart" the node, run `qctl create network` which will redeploy the
K8s deployment.