### PR TITLE
[qctl] add support for acceptance tests.

### DIFF
--- a/qctl/README.md
+++ b/qctl/README.md
@@ -25,6 +25,7 @@ COMMANDS:
    test             run tests against the running network
    generate         options for generating base config / resources
    delete, destroy  options for deleting networks / resources
+   stop             options for stopping nodes.
    update           options for updating nodes / resources
    deploy           options for deploying networks / resources to K8s
    geth             options for interacting with geth
@@ -52,8 +53,8 @@ The Quorum network values are:
 
   num nodes = 4
   consensus = istanbul
-  quorumVersion = 2.6.0
-  tmVersion = 0.10.4
+  quorumVersion = 2.7.0
+  tmVersion = 0.10.6
   transactionnManger = tessera
   chainId = 1000
 
@@ -73,9 +74,9 @@ $> qctl generate network --create
   Network Configuration:
   num nodes = 4
   consensus = istanbul
-  quorumVersion = 2.6.0
+  quorumVersion = 2.7.0
   (node1) txManger = tessera
-  (node1) tmVersion = 0.10.4
+  (node1) tmVersion = 0.10.6
   (node1) chainId = 1000
 
   To enable future commands, e.g. qctl create network, qctl delete network, to use this network
@@ -95,7 +96,7 @@ $>  export QUBE_K8S_DIR=/Users/matcha/Workspace.Quorum/qctl-config/out
 This requires a running K8s network, either local (kind, minikube, docker on desktop) or cloud provider (GKE, EKS, Azure),
 or other managed K8s runtime.
 
-Start up your K8s environment, e.g. `minikube start --memory 8192`
+Start up your K8s environment, e.g. `minikube start --memory 6144`
 
 ```
 $> export QUBE_K8S_DIR=/Users/matcha/Workspace.Quorum/qctl-config/out
@@ -116,6 +117,7 @@ $> qctl ls nodes
 $> qctl ls nodes --all
 $> qctl ls nodes --bare --enode
 $> qctl ls nodes --bare --enode quorum-node1
+"enode://3a1912d30257c99d10f3795bff6731493f7985dfaf188f85f46ff8c8074d98a456eab1a850a6f57cdc3f28611cbfb10da001e7a3f10a73baaf095866b7f1acb1@quorum-node1:30303?discport=0&raftport=50401"
 
 ## To add a new node to the network run: add, generate, deploy
 ## 1. add the node to the config
@@ -134,9 +136,9 @@ $> qctl deploy network --wait
 ### Run the test contract on the node (public/private) 
 ```
 # tests both private and public contract deployment, if not flag is specified.
-> qctl test contract node1
-> qctl test contract node1 --private
-> qctl test contract node1 --public
+> qctl test contract quorum-node1
+> qctl test contract quorum-node1 --private
+> qctl test contract quorum-node1 --public
 ```
 
 ### Execute a geth command on a specific node
@@ -146,7 +148,18 @@ $> qctl deploy network --wait
 
 ### Attach to geth on a specific node
 ```
-> qctl geth attach node1
+> qctl geth attach quorum-node1
+
+connecting to geth /etc/quorum/qdata
+Welcome to the Geth JavaScript console!
+
+instance: Geth/v1.9.7-stable-6005360c(quorum-v2.7.0)/linux-amd64/go1.13.13
+coinbase: 0x5dc833a384369714e05d1311e40a8b244be772af
+at block: 19 (Tue, 06 Oct 2020 00:24:05 UTC)
+ datadir: /etc/quorum/qdata/dd
+ modules: admin:1.0 debug:1.0 eth:1.0 istanbul:1.0 miner:1.0 net:1.0 personal:1.0 quorumExtension:1.0 rpc:1.0 txpool:1.0 web3:1.0
+
+>
 ```
 
 ### Follow Quorum Logs
@@ -158,3 +171,9 @@ $> qctl deploy network --wait
 ```
 > qctl logs -f quorum-node1 tessera 
 ```
+
+### (for developers) Run the acceptance test
+example running with minikube
+```
+> qctl test accepttest --node-ip=$(minikube ip)
+``` 

--- a/qctl/acceptancetestyaml.go
+++ b/qctl/acceptancetestyaml.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"os"
+)
+
+var (
+	acceptanceTestTemplateYaml = `
+    quorum:
+      nodes:
+        Node1:
+          privacy-address: 4qceb9wVWDrYXqwgmu23clRQDHZeFTP0xDfEpMzm7yg=
+          url: http://192.168.64.49:30102
+          third-party-url: http://192.168.64.49:32614
+    `
+)
+
+type AcceptTestConfig struct {
+	Quorum struct {
+		Nodes []ATNodeEntry
+	}
+}
+
+type ATNodeEntry struct {
+	TmPublicKey string `yaml:"privacy-address"`
+	GethURL     string `yaml:"url"`
+	TmURL       string `yaml:"third-party-url"`
+}
+
+func LoadAcTYamlConfig(filename string) (AcceptTestConfig, error) {
+	config := AcceptTestConfig{}
+	fileBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		log.Fatalf("error reading file: %v err: %v", filename, err)
+		return config, err
+	}
+
+	err = yaml.Unmarshal(fileBytes, &config)
+	if err != nil {
+		log.Fatalf("error unmarshalling file: %v err: %v", filename, err)
+		return config, err
+	}
+	return config, nil
+}
+
+func WriteAcTYamlConfig(config AcceptTestConfig, filename string) (AcceptTestConfig, error) {
+	bs, err := yaml.Marshal(&config)
+	if err != nil {
+		log.Fatalf("error: %v", err)
+		return config, err
+	}
+	ioutil.WriteFile(filename, bs, os.ModePerm)
+	return config, err
+}
+
+func (q AcceptTestConfig) ToString() string {
+	d, err := yaml.Marshal(&q)
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+	return string(d)
+}

--- a/qctl/nodecmd.go
+++ b/qctl/nodecmd.go
@@ -935,3 +935,27 @@ func rmService(nodeName string) error {
 	}
 	return err
 }
+
+func getTmPublicKey(nodeName string) string {
+	//c1 := exec.Command("cat", qubeK8sDir+"/config/" + nodeKeyDir + "tm.pub")
+	//kc get configMaps quorum-node3-tm-key-config -o yaml | grep "tm.pub:"
+	c1 := exec.Command("kubectl", "get", "configMap", nodeName+"-tm-key-config", "-o", "yaml")
+	c2 := exec.Command("grep", "tm.pub:")
+
+	r, w := io.Pipe()
+	c1.Stdout = w
+	c2.Stdin = r
+
+	var out bytes.Buffer
+	c2.Stdout = &out
+	c1.Start()
+	c2.Start()
+	c1.Wait()
+	w.Close()
+	c2.Wait()
+	// output will look like:
+	// tm.pub: dF+Y81qRKI3Noh6ldI+FnQmqmjRYvOqLCaooTi5txi4=
+	tmPublicKey := strings.ReplaceAll(out.String(), "tm.pub:", "")
+	tmPublicKey = strings.TrimSpace(tmPublicKey)
+	return tmPublicKey
+}

--- a/qctl/qctl.go
+++ b/qctl/qctl.go
@@ -36,6 +36,7 @@ func main() {
 			Usage: "run tests against the running network",
 			Subcommands: []*cli.Command{
 				&testContractCmd,
+				&acceptanceTestRunCmd,
 			},
 		},
 		{

--- a/qctl/testcmd.go
+++ b/qctl/testcmd.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"fmt"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
+	"io/ioutil"
 	"os/exec"
+	"strings"
 )
 
 var (
@@ -69,5 +72,233 @@ var (
 		},
 	}
 
-	// TODO: support acceptance tests
+	// qctl test accepttest --node-ip=$(minikube ip)
+	acceptanceWriteConfigCmd = cli.Command{
+		Name:    "accepttest",
+		Usage:   "output the acceptance test config file",
+		Aliases: []string{"ac"},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "config, c",
+				Usage:    "Load configuration from `FULL_PATH_FILE`",
+				EnvVars:  []string{"QUBE_CONFIG"},
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "k8sdir",
+				Usage:    "k8sdir where the resources are stored, acceptance test config stored here for now.",
+				EnvVars:  []string{"QUBE_K8S_DIR"},
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:  "node-ip",
+				Usage: "the IP of the K8s node, e.g. minikube ip ",
+				Value: "K8S_NODE_IP",
+			},
+		},
+		Action: func(c *cli.Context) error {
+
+			k8sNodeIp := c.String("node-ip")
+			// TODO: abstract out config check used everywhere
+			configFile := c.String("config")
+			k8sdir := c.String("k8sdir")
+			// get the current directory path, we'll use this in case the config file passed in was a relative path.
+			pwdCmd := exec.Command("pwd")
+			b := runCmd(pwdCmd)
+			pwd := strings.TrimSpace(b.String())
+
+			if configFile == "" {
+				c.App.Run([]string{"qctl", "help", "accepttest"})
+
+				// QUBE_CONFIG or flag
+				fmt.Println()
+
+				fmt.Println()
+				red.Println("  --config flag must be provided.")
+				red.Println("             or ")
+				red.Println("     QUBE_CONFIG environment variable needs to be set to your config file.")
+				fmt.Println()
+				red.Println(" If you need to generate a qubernetes.yaml config use the command: ")
+				fmt.Println()
+				green.Println("   qctl generate config")
+				fmt.Println()
+				return cli.Exit("--config flag must be set to the fullpath of your config file.", 3)
+			}
+
+			// the config file must exist or this is an error.
+			if fileExists(configFile) {
+				// check if config file is full path or relative path.
+				if !strings.HasPrefix(configFile, "/") {
+					configFile = pwd + "/" + configFile
+				}
+
+			} else {
+				c.App.Run([]string{"qctl", "help", "init"})
+				return cli.Exit(fmt.Sprintf("ConfigFile must exist! Given configFile [%v]", configFile), 3)
+			}
+
+			configFileYaml, err := LoadYamlConfig(configFile)
+			if err != nil {
+				log.Fatal("config file [%v] could not be loaded into the valid quebernetes yaml. err: [%v]", configFile, err)
+			}
+			acceptanceTestYaml := createAcceptanceTestConfigString(configFileYaml, k8sNodeIp)
+			fmt.Println(acceptanceTestYaml)
+			//fmt.Println(config.ToString())
+			configBytes := []byte(acceptanceTestYaml)
+			acceptanceTestYamlFile := k8sdir + "/config/application-qctl-generated.yml"
+			// write the generated file out to disk this file will be used to initialize the network.
+			// TODO: it might be best to store in K8s itself
+			ioutil.WriteFile(acceptanceTestYamlFile, configBytes, 0644)
+			return nil
+		},
+	}
+	// qctl test accepttest --node-ip=$(minikube ip)
+	// docker run --rm -v $(pwd):/tmp/config -e "SPRING_CONFIG_ADDITIONALLOCATION=file:/tmp/config/" -e "SPRING_PROFILES_ACTIVE=${PROFILE}" quorumengineering/acctests:latest test  -Dtags="basic && !externally-signed && !personal-api-signed && !eth-api-signed"
+	acceptanceTestRunCmd = cli.Command{
+		Name:    "accepttest",
+		Aliases: []string{"accepttests, acceptancetest, acceptancetests"},
+		Usage:   "run the acceptance tests.",
+		// TODO: pass in tags, and the config file, will also need the k8s ip...unless
+		// additionally pass in the file, and the tags, then no additional config needed
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "config, c",
+				Usage:    "Load configuration from `FULL_PATH_FILE`",
+				EnvVars:  []string{"QUBE_CONFIG"},
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "k8sdir",
+				Usage:    "k8sdir where the resources are stored, acceptance test config stored here for now.",
+				EnvVars:  []string{"QUBE_K8S_DIR"},
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "node-ip",
+				Usage:    "the IP of the K8s node, e.g. minikube ip ",
+				Value:    "K8S_NODE_IP",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:  "tags",
+				Aliases: []string{"t", "tag"},
+				Usage: "tags indicating which test to run, if not set, defaults to: (basic || basic-{CONSENSUS} || networks/typical::{CONSENSUS}) && !extension ",
+			},
+		},
+		Action: func(c *cli.Context) error {
+
+			k8sdir := c.String("k8sdir")
+			k8sNodeIp := c.String("node-ip")
+
+			if k8sdir == "" {
+				c.App.Run([]string{"qctl", "help", "accepttest"})
+
+				// QUBE_CONFIG or flag
+				fmt.Println()
+
+				fmt.Println()
+				red.Println("  --k8sdir flag must be provided.")
+				red.Println("             or ")
+				red.Println("     QUBE_K8S_DIR environment variable needs to be set to your k8sdir.")
+				fmt.Println()
+			}
+
+			// TODO: abstract out config check used everywhere
+			configFile := c.String("config")
+			// V1 keep the file on a known place on disc
+			// acceptanceTestYaml := k8sdir + "/config/application-qctl-generated.yml"
+			// end V1
+			configFileYaml, err := LoadYamlConfig(configFile)
+			if err != nil {
+				log.Fatal("config file [%v] could not be loaded into the valid quebernetes yaml. err: [%v]", configFile, err)
+			}
+
+			// acceptance test file must be prefixed with application, e.g. `application-$MYNAME.yaml`
+
+			// if an acceptance test config file wasn't provided, create one against the running network now.
+			acceptanceTestYaml := createAcceptanceTestConfigString(configFileYaml, k8sNodeIp)
+			configBytes := []byte(acceptanceTestYaml)
+			// write the generated file out to disk this file will be used to initialize the network.
+			// TODO: it might be best to store in K8s itself
+			acceptanceTestYamlFile := k8sdir + "/config/application-qctl-generated.yml"
+			ioutil.WriteFile(acceptanceTestYamlFile, configBytes, 0644)
+
+			acceptanceTestProfile := "qctl-generated"
+			// Depending on the consensus (raft or istanbul) of the network, set the tags accordingly.
+			tags := c.String("tags")
+			if tags == "" {
+				if configFileYaml.Genesis.Consensus == RaftConsensus {
+					tags = "(basic || basic-raft || networks/typical::raft) && !extension"
+				} else {
+					tags = "(basic || basic-istanbul || networks/typical::istanbul) && !extension"
+				}
+			}
+			green.Println("using profile file: " + acceptanceTestYamlFile)
+			// if debugging include -X for mvn output
+			cmd := exec.Command("docker", "run", "--rm", "-v", k8sdir+"/config:/tmp/config", "-e", "SPRING_CONFIG_ADDITIONALLOCATION=file:/tmp/config/", "-e", "SPRING_PROFILES_ACTIVE="+acceptanceTestProfile, "quorumengineering/acctests:latest", "test", "-Dtags="+tags)
+			// e.g. docker run --rm -v /Users/libby/Workspace.Quorum/qctl-config/out/config:/tmp/config -e SPRING_CONFIG_ADDITIONALLOCATION=file:/tmp/config/ -e SPRING_PROFILES_ACTIVE=qctl-generated quorumengineering/acctests:latest test -Dtags='(basic || basic-istanbul || networks/typical::istanbul) && !extension'
+			fmt.Println(cmd)
+			dropIntoCmd(cmd)
+			return nil
+		},
+	}
 )
+
+// acceptance test expects a config file with node names labelled in sequential order, Node1, Node2:
+//quorum:
+//nodes:
+//Node1:
+//	privacy-address: WC6yWjDXG9uFQTTfV+bkTr5GbqjmH7DotcOYqeSajgs=
+//		url: http://192.168.64.49:32507
+//	third-party-url: http://192.168.64.49:31375
+//Node2:
+//	privacy-address: t+lu+T9VoTWfQMyF7wiFsiEKARaQqgvOJynNfrsSbAk=
+//		url: http://192.168.64.49:32106
+//	third-party-url: http://192.168.64.49:30968
+//
+// TODO: can we update the format to use unique names, and yaml lists.
+//quorum:
+//  nodes:
+//  - name: quorum-node1
+//    privacy-address: WC6yWjDXG9uFQTTfV+bkTr5GbqjmH7DotcOYqeSajgs=
+//    url: http://192.168.64.49:32507
+//    third-party-url: http://192.168.64.49:31375
+//  - name: quorum-node2
+//    privacy-address: t+lu+T9VoTWfQMyF7wiFsiEKARaQqgvOJynNfrsSbAk=
+//    url: http://192.168.64.49:32106
+//    third-party-url: http://192.168.64.49:30968
+func createAcceptanceTestConfigString(configFileYaml QConfig, k8sNodeIp string) string {
+	acceptanceTestYaml := AcceptTestConfig{}
+	for _, node := range configFileYaml.Nodes {
+		// get nodes from config, and set the necessary tm public key, geth and tessera urls, using NodePort.
+		serviceNodePort := serviceInfoForNode(node.NodeUserIdent, ServiceTypeNodePort, "")
+		tmPublicKey := getTmPublicKey(node.NodeUserIdent)
+		nodeEntry := ATNodeEntry{}
+		nodeEntry.GethURL = "http://" + k8sNodeIp + ":" + serviceNodePort.NodePortGeth
+		nodeEntry.TmPublicKey = tmPublicKey
+		nodeEntry.TmURL = "http://" + k8sNodeIp + ":" + serviceNodePort.NodePortTm
+
+		acceptanceTestYaml.Quorum.Nodes = append(acceptanceTestYaml.Quorum.Nodes, nodeEntry)
+	}
+	// TODO this is really hideous, better to change the acceptance test to take a yaml file that has a list of node with a name attributes:
+	//quorum:
+	//  nodes:
+	//  - name: node1
+	//    privacy-address: WC6yWjDXG9uFQTTfV+bkTr5GbqjmH7DotcOYqeSajgs=
+	//    url: http://192.168.64.49:32507
+	//    third-party-url: http://192.168.64.49:31375
+	//  - name: node2
+	//    privacy-address: t+lu+T9VoTWfQMyF7wiFsiEKARaQqgvOJynNfrsSbAk=
+	//    url: http://192.168.64.49:32106
+	//    third-party-url: http://192.168.64.49:30968
+	acceptanceTestUpdatedYaml := acceptanceTestYaml.ToString()
+	// since node name must be in the for form Node(i+1)
+	for i := 0; i < len(configFileYaml.Nodes); i++ {
+		//acceptanceTestUpdatedYaml = strings.Replace(acceptanceTestUpdatedYaml, "- privacy-address:", "  " + node.NodeUserIdent + ": \n      privacy-address:", 1)
+		nodeName := fmt.Sprintf("Node%d", i+1)
+		acceptanceTestUpdatedYaml = strings.Replace(acceptanceTestUpdatedYaml, "- privacy-address:", "  "+nodeName+": \n      privacy-address:", 1)
+	}
+	acceptanceTestUpdatedYaml = strings.ReplaceAll(acceptanceTestUpdatedYaml, " url:", "   url:")
+	acceptanceTestUpdatedYaml = strings.ReplaceAll(acceptanceTestUpdatedYaml, "third-party-url:", "  third-party-url:")
+	return acceptanceTestUpdatedYaml
+}


### PR DESCRIPTION
Add support for running acceptance tests against a running network:
qctl test accepttest --node-ip={K8S_NODEIP}

Requires the node-ip of the running K8s deployment. To overwrite the
default tags, use the --tags flags and explicitly set the acceptance
test tags to run. The tags have defaults depending on the consensus of
the network:
raft: "(basic || basic-raft || networks/typical::raft) && !extension"
ibft: "(basic || basic-istanbul || networks/typical::istanbul) && !extension"

Update README.md