### PR TITLE
[qctl] check errors when writing files.

### DIFF
--- a/qctl/configcmd.go
+++ b/qctl/configcmd.go
@@ -159,9 +159,11 @@ var (
 			}
 			configBytes := []byte(configYaml.ToString())
 
-			// write the generated file out to disk this file will be used to initialize the network.
-			ioutil.WriteFile(configFile, configBytes, 0644)
-
+			// try to write the generated file out to disk this file will be used to initialize the network.
+			err := ioutil.WriteFile(configFile, configBytes, 0644)
+			if err != nil {
+				log.Fatal("error writing configFile to [%v]. err: [%v]", configFile, err)
+			}
 			// TODO: check the config file was properly generated
 			// Set the configfile to the full path
 			if fileExists(configFile) {

--- a/qctl/configyaml.go
+++ b/qctl/configyaml.go
@@ -117,7 +117,7 @@ func WriteYamlConfig(qconfig QConfig, filename string) (QConfig, error) {
 		log.Fatalf("error: %v", err)
 		return qconfig, err
 	}
-	ioutil.WriteFile(filename, bs, os.ModePerm)
+	err = ioutil.WriteFile(filename, bs, os.ModePerm)
 	return qconfig, err
 }
 

--- a/qctl/testcmd.go
+++ b/qctl/testcmd.go
@@ -146,9 +146,12 @@ var (
 			//fmt.Println(config.ToString())
 			configBytes := []byte(acceptanceTestYaml)
 			acceptanceTestYamlFile := k8sdir + "/config/application-qctl-generated.yml"
-			// write the generated file out to disk this file will be used to initialize the network.
+			// try writing the generated file out to disk this file will be used to initialize the network.
 			// TODO: it might be best to store in K8s itself
-			ioutil.WriteFile(acceptanceTestYamlFile, configBytes, 0644)
+			err = ioutil.WriteFile(acceptanceTestYamlFile, configBytes, 0644)
+			if err != nil {
+				log.Fatal("error writing acceptanceTestYamlFil to [%v]. err: [%v]", acceptanceTestYamlFile, err)
+			}
 			return nil
 		},
 	}
@@ -180,9 +183,9 @@ var (
 				Required: true,
 			},
 			&cli.StringFlag{
-				Name:  "tags",
+				Name:    "tags",
 				Aliases: []string{"t", "tag"},
-				Usage: "tags indicating which test to run, if not set, defaults to: (basic || basic-{CONSENSUS} || networks/typical::{CONSENSUS}) && !extension ",
+				Usage:   "tags indicating which test to run, if not set, defaults to: (basic || basic-{CONSENSUS} || networks/typical::{CONSENSUS}) && !extension ",
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -218,10 +221,13 @@ var (
 			// if an acceptance test config file wasn't provided, create one against the running network now.
 			acceptanceTestYaml := createAcceptanceTestConfigString(configFileYaml, k8sNodeIp)
 			configBytes := []byte(acceptanceTestYaml)
-			// write the generated file out to disk this file will be used to initialize the network.
+			// try writing the generated file out to disk this file will be used to initialize the network.
 			// TODO: it might be best to store in K8s itself
 			acceptanceTestYamlFile := k8sdir + "/config/application-qctl-generated.yml"
-			ioutil.WriteFile(acceptanceTestYamlFile, configBytes, 0644)
+			err = ioutil.WriteFile(acceptanceTestYamlFile, configBytes, 0644)
+			if err != nil {
+				log.Fatal("error writing acceptanceTestYamlFil to [%v]. err: [%v]", acceptanceTestYamlFile, err)
+			}
 
 			acceptanceTestProfile := "qctl-generated"
 			// Depending on the consensus (raft or istanbul) of the network, set the tags accordingly.


### PR DESCRIPTION
when writing files to disk, e.g. config, accept test config, if there is
an error log it and error out.