### PR TITLE
Allow setting of full image for transaction manger.

### DIFF
--- a/qctl/configcmd.go
+++ b/qctl/configcmd.go
@@ -59,6 +59,10 @@ var (
 				Usage: "The full repo + image name of the quorum image.",
 			},
 			&cli.StringFlag{
+				Name:  "tmimagefull",
+				Usage: "The full repo + image name of the tm image.",
+			},
+			&cli.StringFlag{
 				Name:  "gethparams",
 				Usage: "additional geth startup params to run on the node.",
 			},
@@ -101,6 +105,7 @@ var (
 			consensus := c.String("consensus")
 			chainId := c.String("chainid")
 			qimagefull := c.String("qimagefull")
+			tmImageFull := c.String("tmimagefull")
 			gethparams := c.String("gethparams")
 			isMonitoring := c.Bool("monitor")
 			isCakeshop := c.Bool("cakeshop")
@@ -116,8 +121,9 @@ var (
 					DockerRepoFull: qimagefull,
 				}
 				tm := Tm{
-					Name:      transactionManger,
-					TmVersion: tmVersion,
+					Name:           transactionManger,
+					TmVersion:      tmVersion,
+					DockerRepoFull: tmImageFull,
 				}
 				quorumEntry := QuorumEntry{
 					Quorum: quorum,

--- a/qctl/configyaml.go
+++ b/qctl/configyaml.go
@@ -35,8 +35,9 @@ type Quorum struct {
 }
 
 type Tm struct {
-	Name      string `yaml:"Name"`
-	TmVersion string `yaml:"Tm_Version"`
+	Name           string `yaml:"Name"`
+	TmVersion      string `yaml:"Tm_Version"`
+	DockerRepoFull string `yaml:"Docker_Repo_Full"` //tessera-local:latest
 }
 
 type NodeEntry struct {

--- a/qubernetes
+++ b/qubernetes
@@ -56,7 +56,11 @@ def set_node_template_vars(values)
   if values.dig("quorum","tm","Docker_Repo")
     @Tm_Docker_Repo = values["quorum"]["tm"]["Docker_Repo"]
   end
-
+  # Allow the user to set the full repo, e.g. tessera-local, e.g. the case they are using skaffold, or other local dev.
+  @TM_Docker_Repo_Full = ""
+  if values.dig("quorum","tm", "Docker_Repo_Full")
+    @TM_Docker_Repo_Full = values["quorum"]["tm"]["Docker_Repo_Full"]
+  end
   return
 end
 

--- a/templates/k8s/quorum-deployment.yaml.erb
+++ b/templates/k8s/quorum-deployment.yaml.erb
@@ -80,7 +80,12 @@ spec:
       containers:
     <%- if @Tm_Name == "constellation"  -%>
       - name: constellation
+        <%- if @TM_Docker_Repo_Full != "" -%>
+        image: <%= @TM_Docker_Repo_Full %>
+        imagePullPolicy: Never
+        <%- else -%>
         image:  <%= @Tm_Docker_Repo %>/constellation:<%= @Tm_Version %>
+        <%- end -%>
         command: ["sh"]
         args:
         - "-cx"
@@ -98,7 +103,12 @@ spec:
            /usr/local/bin/constellation-node $args  2>&1 | tee -a $QUORUM_HOME/logs/tm.log; "
      <%- else -%>
       - name: tessera
+        <%- if @TM_Docker_Repo_Full != "" -%>
+        image: <%= @TM_Docker_Repo_Full %>
+        imagePullPolicy: Never
+        <%- else -%>
         image: <%= @Tm_Docker_Repo %>/tessera:<%= @Tm_Version %>
+        <%- end -%>
         command: ["sh"]
         args:
         - "-cx"


### PR DESCRIPTION
* in base k8s templates for deployments, allow the full transaction
manager image to be set, for example when using a local image.
* [qctl] allow for init, add, updating and displaying of transaction
manager full image.