### PR TITLE
[qctl] when listing urls get services from config.

### DIFF
--- a/qctl/go.mod
+++ b/qctl/go.mod
@@ -3,6 +3,7 @@ module github.com/ConsenSys/qubernetes/qctl
 go 1.13
 
 require (
+	github.com/deckarep/golang-set v1.7.1
 	github.com/fatih/color v1.9.0
 	github.com/mitchellh/gox v1.0.1 // indirect
 	github.com/sirupsen/logrus v1.6.0

--- a/qctl/go.sum
+++ b/qctl/go.sum
@@ -42,6 +42,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set v1.7.1 h1:SCQV0S6gTtp6itiFrTqI+pfmJ4LN85S1YzhDf9rTHJQ=
+github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=

--- a/qctl/testcmd.go
+++ b/qctl/testcmd.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
-	"github.com/urfave/cli/v2"
 	"io/ioutil"
 	"os/exec"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
 )
 
 var (
@@ -277,7 +278,7 @@ func createAcceptanceTestConfigString(configFileYaml QConfig, k8sNodeIp string) 
 	acceptanceTestYaml := AcceptTestConfig{}
 	for _, node := range configFileYaml.Nodes {
 		// get nodes from config, and set the necessary tm public key, geth and tessera urls, using NodePort.
-		serviceNodePort := serviceInfoForNode(node.NodeUserIdent, ServiceTypeNodePort, "")
+		serviceNodePort := serviceInfoByPrefix(node.NodeUserIdent, ServiceTypeNodePort, "")
 		tmPublicKey := getTmPublicKey(node.NodeUserIdent)
 		nodeEntry := ATNodeEntry{}
 		nodeEntry.GethURL = "http://" + k8sNodeIp + ":" + serviceNodePort.NodePortGeth

--- a/qctl/utils.go
+++ b/qctl/utils.go
@@ -3,13 +3,14 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/fatih/color"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/fatih/color"
+	log "github.com/sirupsen/logrus"
 )
 
 var (


### PR DESCRIPTION
* The quorum services to list should be obtained from the config being
used. Show auxiliary services (cakeshop, monitoring) first, then all
quroum node services.
* if --node flags are set, only show the serivces that are both in the
config and requested with a --node flag.