### PR TITLE
[qctl] check for docker errors.

### DIFF
--- a/qctl/networkcmd.go
+++ b/qctl/networkcmd.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
-	"github.com/urfave/cli/v2"
 	"os"
 	"os/exec"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
 )
 
 var (
@@ -211,7 +212,15 @@ var (
 			if qubernetesVersion == "latest" {
 				fmt.Println("trying to pull latest container")
 				pullContainerCmd := exec.Command("docker", "pull", "quorumengineering/qubernetes:latest")
-				dropIntoCmd(pullContainerCmd)
+				err = dropIntoCmd(pullContainerCmd)
+				if err != nil {
+					fmt.Println()
+					red.Println(fmt.Sprintf("Error running trying to generate network resources."))
+					red.Println(fmt.Sprintf("Command that failed: [%v]", pullContainerCmd.String()))
+					red.Println(fmt.Sprintf("Is Docker running on your machine? [%v]", err))
+					fmt.Println()
+					return cli.Exit(fmt.Sprintf("Docker must be running on host, cmd failed [%v]", pullContainerCmd.String()), 3)
+				}
 				fmt.Println()
 				fmt.Println()
 			}
@@ -224,7 +233,17 @@ var (
 			}
 
 			//fmt.Println(cmd)
-			dropIntoCmd(cmd)
+			err = dropIntoCmd(cmd)
+			if err != nil {
+				fmt.Println()
+				red.Println(fmt.Sprintf("Error running trying to generate network resources with the qubernetes container."))
+				red.Println(fmt.Sprintf("Command that failed:"))
+				red.Println(fmt.Sprintf(cmd.String()))
+				fmt.Println()
+				red.Println(fmt.Sprintf("Is Docker running on your machine? [%v]", err))
+				fmt.Println()
+				return cli.Exit(fmt.Sprintf("Docker must be running on host, cmd failed \n %v", cmd.String()), 3)
+			}
 			fmt.Println()
 
 			fmt.Println("=======================================================================================")

--- a/qctl/testcmd.go
+++ b/qctl/testcmd.go
@@ -245,7 +245,17 @@ var (
 			cmd := exec.Command("docker", "run", "--rm", "-v", k8sdir+"/config:/tmp/config", "-e", "SPRING_CONFIG_ADDITIONALLOCATION=file:/tmp/config/", "-e", "SPRING_PROFILES_ACTIVE="+acceptanceTestProfile, "quorumengineering/acctests:latest", "test", "-Dtags="+tags)
 			// e.g. docker run --rm -v /Users/libby/Workspace.Quorum/qctl-config/out/config:/tmp/config -e SPRING_CONFIG_ADDITIONALLOCATION=file:/tmp/config/ -e SPRING_PROFILES_ACTIVE=qctl-generated quorumengineering/acctests:latest test -Dtags='(basic || basic-istanbul || networks/typical::istanbul) && !extension'
 			fmt.Println(cmd)
-			dropIntoCmd(cmd)
+			err = dropIntoCmd(cmd)
+			if err != nil {
+				fmt.Println()
+				red.Println(fmt.Sprintf("Error running trying to run acceptance test via the quorumengineering/acctests container ."))
+				red.Println(fmt.Sprintf("Command that failed:"))
+				red.Println(fmt.Sprintf(cmd.String()))
+
+				red.Println(fmt.Sprintf("Is Docker running on your machine? [%v]", err))
+				fmt.Println()
+				return cli.Exit(fmt.Sprintf("Docker must be running on host, cmd failed \n %v", cmd.String()), 3)
+			}
 			return nil
 		},
 	}

--- a/qctl/utils.go
+++ b/qctl/utils.go
@@ -219,12 +219,13 @@ func showPods(namespace string) {
 
 // https://www.reddit.com/r/golang/comments/2nd4pq/how_can_i_open_an_interactive_subprogram_from/
 // runs a subcommand in interactive mode.
-func dropIntoCmd(cmd *exec.Cmd) {
+func dropIntoCmd(cmd *exec.Cmd) error {
 	//log.Printf(cmd.String())
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
-	cmd.Run()
+	err := cmd.Run()
+	return err
 }
 
 func runCmd(cmd *exec.Cmd) bytes.Buffer {


### PR DESCRIPTION
When running generate network, and acceptance test, containers are used
(qubernetes and acctests), if docker returns an error, log the error and
fail with an exit code > 0.