### PR TITLE
add clear option for generating resources

### DIFF
--- a/qube-init
+++ b/qube-init
@@ -11,7 +11,8 @@ OptionParser.new do |opts|
   opts.banner = "Usage: ./qube-init [options]"
 
   opts.on("-a", "--action [ACTION]", String,
-            "create: override out directory and generate new resources.
+            "clear: override out directory and generate new resources.
+                                     create: keep out directory and generate new resources.
                                      update: keep out directory and only add additional resources.") do |a|
     options[:action] = a
   end

--- a/quorum-init
+++ b/quorum-init
@@ -11,7 +11,8 @@ OptionParser.new do |opts|
   opts.banner = "Usage: ./quorum-init [options]"
 
   opts.on("-a", "--action [ACTION]", String,
-            "create: override out directory and generate new resources.
+            "clear: override out directory and generate new resources.
+                                     create: keep out directory and generate new resources.
                                      update: keep out directory and only add additional resources.") do |a|
     options[:action] = a
   end
@@ -38,7 +39,7 @@ puts "using config file: " + @config_file
 # decide to create new resources
 action = options[:action]
 createNew=false
-if (action == 'create')
+if (action == 'clear')
     createNew=true
 end
 


### PR DESCRIPTION
wizard requires the option to keep the out directory and also generate all the resources (including the genesis file)
Now qubernetes we can:
1. clear - wipe out the out directory and generate all new keys and resources
2. create - keep the out directory and generate new resources (option wizard will always use)
3. update - keep out directory and only add additional resources