### PR TITLE
[qctl] when node name required make it an arg.

### DIFF
--- a/qctl/README.md
+++ b/qctl/README.md
@@ -123,7 +123,7 @@ at block: 19 (Tue, 06 Oct 2020 00:24:05 UTC)
 To add a new node to the network run: add, generate, deploy.  
 `add` adds the node to the qubernetes config
 ```
-$> qctl add node --name=quorum-node5
+$> qctl add node quorum-node5
 $> qctl ls nodes 
 ```
 cakeshop and monitoring can also be added the same way

--- a/qctl/nodecmd.go
+++ b/qctl/nodecmd.go
@@ -293,20 +293,16 @@ var (
 	//qctl add node --id=node3 --consensus=ibft --quorum
 	//TODO: get the defaults from the config file.
 	nodeAddCommand = cli.Command{
-		Name:    "node",
-		Usage:   "add new nodes",
-		Aliases: []string{"n", "nodes"},
+		Name:      "node",
+		Usage:     "add new node",
+		Aliases:   []string{"n", "nodes"},
+		ArgsUsage: "UniqueNodeName",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "config, c",
 				Usage:   "Load configuration from `FULL_PATH_FILE`",
 				EnvVars: []string{"QUBE_CONFIG"},
 				//Required: true,
-			},
-			&cli.StringFlag{
-				Name:     "name",
-				Usage:    "Unique name of node to create",
-				Required: true,
 			},
 			// TODO: set default to Node-name-key-dir
 			&cli.StringFlag{
@@ -337,8 +333,14 @@ var (
 			},
 		},
 		Action: func(c *cli.Context) error {
+			name := c.Args().First()
+			// node name argument is required to update a node
+			if name == "" {
+				c.App.Run([]string{"qctl", "help", "node"})
+				red.Println("  required argument: Unique NodeName of node you wish to add.")
+				return cli.Exit("  required argument: Unique NodeName of node you wish to add.", 3)
+			}
 			// defaults should be obtained from the config
-			name := c.String("name")
 			keyDir := c.String("keydir")
 			if keyDir == "" {
 				keyDir = fmt.Sprintf("key-%s", name)
@@ -443,20 +445,16 @@ var (
 	}
 	// TODO: consolidate this and add node
 	nodeUpdateCommand = cli.Command{
-		Name:    "node",
-		Usage:   "update node",
-		Aliases: []string{"n", "nodes"},
+		Name:      "node",
+		Usage:     "update node",
+		Aliases:   []string{"n", "nodes"},
+		ArgsUsage: "NodeName",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "config, c",
 				Usage:   "Load configuration from `FULL_PATH_FILE`",
 				EnvVars: []string{"QUBE_CONFIG"},
 				//Required: true,
-			},
-			&cli.StringFlag{
-				Name:     "name",
-				Usage:    "Unique name of node to create",
-				Required: true,
 			},
 			// TODO: set default to Node-name-key-dir
 			&cli.StringFlag{
@@ -495,8 +493,14 @@ var (
 			},
 		},
 		Action: func(c *cli.Context) error {
+			name := c.Args().First()
+			// node name argument is required to update a node
+			if name == "" {
+				c.App.Run([]string{"qctl", "help", "node"})
+				red.Println("  NodeName required to update a node.")
+				return cli.Exit("  NodeName required to update a node.", 3)
+			}
 			// defaults should be obtained from the config
-			name := c.String("name")
 			keyDir := c.String("keydir")
 			if keyDir == "" {
 				keyDir = fmt.Sprintf("key-%s", name)
@@ -583,7 +587,6 @@ var (
 					}
 					updatedNode = nodeEntry
 					configFileYaml.Nodes[i] = updatedNode
-					red.Println(fmt.Sprintf("updated nodes is [%v]", updatedNode))
 				}
 			}
 			// If the node name the user entered to update does not exists, error out and notify the user.
@@ -617,11 +620,11 @@ var (
 	// qctl ls node --name --consensus --quorumversion
 	// qctl ls node --name --consensus --quorumversion --tmversion --tmname
 	nodeListCommand = cli.Command{
-		Name:    "node",
-		Usage:   "list nodes info",
-		Aliases: []string{"n", "nodes"},
+		Name:      "node",
+		Usage:     "list nodes info",
+		Aliases:   []string{"n", "nodes"},
+		ArgsUsage: "NodeName",
 		Flags: []cli.Flag{
-
 			&cli.StringFlag{
 				Name:     "config, c",
 				Usage:    "Load configuration from `FULL_PATH_FILE`",


### PR DESCRIPTION
when the node name is required for node commands, make it a required
argument instead of a `--name` flag, as this is more consistent.
> qctl add node [flags] NodeName
> qctl update node [flags] NodeName
> qctl ls node [flags] NodeName