### PR TITLE
[qctl] helper scripts for add/remove raft nodes.

### DIFF
--- a/qctl/scripts/addraftnode.sh
+++ b/qctl/scripts/addraftnode.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+if [[ "$#" -lt 1 ]]; then
+  echo "./addraftnode.sh NODENAME"
+  exit 1
+fi
+
+NODE_NAME=$1
+qctl ls config
+echo
+qctl add node $NODE_NAME
+
+qctl generate network --update
+ENODE_URL=$(qctl ls node --enodeurl -b $NODE_NAME)
+
+# Get the users input whether they wish to run the update on a certain node.
+printf "${GREEN} Enter node name to run raft.addPeer command on, e.g. quorum-node1 (default): ${NC} \n "
+read NODE_NAME_RUN_CMD
+if [[ "$NODE_NAME_RUN_CMD" == "" ]]; then
+  NODE_NAME_RUN_CMD="quorum-node1"
+fi
+
+echo qctl geth exec $NODE_NAME_RUN_CMD "raft.addPeer(${ENODE_URL})"
+RAFT_ADD_TO_CLUSTER_OUT=$(qctl geth exec $NODE_NAME_RUN_CMD "raft.addPeer(${ENODE_URL})")
+
+## --qimagefull quorum-local-2.7
+echo "Response from raft.addPeer: $RAFT_ADD_TO_CLUSTER_OUT"
+NEW_RAFT_ID=$(echo $RAFT_ADD_TO_CLUSTER_OUT | grep "[0-9]*" | sed 's/^"[0-9]*"//g' | sed 's/^.*pods//g' | sed 's/ //g' | sed $'s/[^[:print:]\t]//g' | sed 's/\[32m//g' | sed 's/\[0m//g' | sed 's/\[31m//g' | sed 's/"//g')
+echo "NEW_RAFT_ID: $NEW_RAFT_ID"
+
+printf "${GREEN} Enter quorum image to use with the node [ quorum-local (default), quorum-local-2.7, quorum-raft-determ ] : ${NC} \n "
+read QUORUM_IMAGE
+echo "QUORUM_IMAGE: $QUORUM_IMAGE"
+
+if [[ "$QUORUM_IMAGE" == "" ]]; then
+  QUORUM_IMAGE="quorum-local"
+fi
+echo
+echo
+
+if [[ "$QUORUM_IMAGE" == "2.7" ||  "$QUORUM_IMAGE" == "2.7.0" || "$QUORUM_IMAGE" == "2.6.0" ||
+      "$QUORUM_IMAGE" == "2.5.0" || "$QUORUM_IMAGE" == "2.4.0" || "$QUORUM_IMAGE" == "2.3.0" ]]; then
+  echo qctl update node --gethparams '--raftjoinexisting $NEW_RAFT_ID' $NODE_NAME
+  qctl update node --gethparams "--raftjoinexisting $NEW_RAFT_ID" $NODE_NAME
+else
+  echo qctl update node --gethparams '--raftjoinexisting $NEW_RAFT_ID' --qimagefull $QUORUM_IMAGE $NODE_NAME
+  qctl update node --gethparams "--raftjoinexisting $NEW_RAFT_ID" --qimagefull $QUORUM_IMAGE $NODE_NAME
+fi
+qctl generate network --update
+qctl deploy network
+
+##echo qctl geth exec $NODE_NAME_RUN_CMD "'raft.addPeer($ENODE_URL)'"
+##echo qctl geth exec $NODE_NAME_RUN_CMD "'raft.cluster'"

--- a/qctl/scripts/deleteraftnode.sh
+++ b/qctl/scripts/deleteraftnode.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Deletion requires:
+# * removing the raftId from the cluster
+# * removing the PVC and Deployment associated with the nodes.
+# * removing the keys / enode id, TODO: we should be able to only regenerate the enodeid.
+#  $>  ./deletenode.sh $QUBE_K8S_DIR quorum-node4
+if [[ "$#" -lt 1 ]]; then
+  #echo "./deletenode.sh QUBE_K8S_DIR NODENAME "
+  echo "./deletenode.sh NODE_NAME"
+  exit 1
+fi
+
+if [[  -z $QUBE_K8S_DIR ]]; then
+  echo "please set $QUBE_K8S_DIR to you K8s out directory."
+  echo "  export QUBE_K8S_DIR=/PATH/TO/K8s/out"
+  echo
+fi
+echo "using QUBE_K8S_DIR $QUBE_K8S_DIR"
+
+NODE_NAME=$1
+# node < 2.7
+TYPE="old"
+
+## check if the node is a new deterministic node
+IS_DETERM_NODE=$(qctl geth exec $NODE_NAME  "raft.cluster" | grep "raftId" | grep '"')
+if [[ $IS_DETERM_NODE != "" ]]; then
+  echo "is deterministic node"
+  TYPE="deterministic"
+else
+  echo "old node"
+fi
+
+## Obtain the RAFT_ID associated to the node from the cluster.
+RAFT_ID=$(qctl geth exec $NODE_NAME "raft.cluster" | grep -A 4 $NODE_NAME | grep raftId | sed "s/raftId://g" | sed "s/\"//g" | sed 's/,//g' | sed 's/ //g')
+
+if [[ $TYPE == "old" ]]; then
+  echo "remove 2.7 or before node from cluster"
+  ## remove hidden chars
+  RAFT_ID=$(echo $RAFT_ID | sed $'s/[^[:print:]\t]//g' | sed 's/\[32m//g' | sed 's/\[0m//g' | sed 's/\[//g' | sed 's/31m//g' | sed 's/\]//g')
+  echo "raft id [$RAFT_ID]"
+  qctl geth exec $NODE_NAME "raft.removePeer(${RAFT_ID})"
+else
+  echo "remove deterministic raft node from cluster"
+  ## remove hidden chars
+  RAFT_ID=$(echo $RAFT_ID | sed $'s/[^[:print:]\t]//g' | sed 's/\[32m//g' | sed 's/\[0m//g')
+  echo "raft id [$RAFT_ID]"
+  qctl geth exec $NODE_NAME "raft.removePeer(\"${RAFT_ID}\")"
+fi
+
+## remove from the K8s cluster
+echo qctl delete node --hard $NODE_NAME
+qctl delete node --hard $NODE_NAME
+
+#rm $K8S_DIR/config/key-${NODE_NAME}/*
+#rmdir $K8S_DIR/config/key-${NODE_NAME}
+
+# Generate a new enode id
+#cd $K8S_DIR/config/key-${NODE_NAME}/
+#bootnode -genkey nodekey
+#bootnode  -nodekeyhex $(cat nodekey) -writeaddress > enode
+
+#kubectl delete deployment ${NODE_NAME}-deployment
+#kubectl delete pvc ${NODE_NAME}-pvc

--- a/qctl/scripts/rmraftid.sh
+++ b/qctl/scripts/rmraftid.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#set -xe
+if [[ "$#" -lt 2 ]]; then
+  echo "./removeraftid.sh RUN_ON_NODE raftId"
+  exit 1
+fi
+
+NODE_NAME=$1
+RAFT_ID=$2
+
+IS_DETERM_NODE=$(qctl geth exec $NODE_NAME  "raft.cluster" | grep "raftId" | grep '"')
+
+if [[ $IS_DETERM_NODE != "" ]]; then
+  echo "is raft deterministic node"
+  qctl geth exec $NODE_NAME "raft.removePeer(\"${RAFT_ID}\")"
+else
+  echo "is old node"
+  ## try first removing from an old node
+  qctl geth exec $NODE_NAME "raft.removePeer(${RAFT_ID})"
+fi


### PR DESCRIPTION
Currently, adding and removing raft nodes includes running
'raft.addPeer(enode)' on the running cluster and
'raft.removePeer(raftId)' script the flow for adding and removing raft
nodes to a running quorum cluster.
./addraftnode.sh quorum-node5
./deleteraftnode.sh quorum-node5