### PR TITLE
save and set nodekey address in a configMap

### DIFF
--- a/quorum-keygen
+++ b/quorum-keygen
@@ -6,6 +6,7 @@ require "erb"
 def set_node_template_vars(values)
   @Node_UserIdent        = values["Node_UserIdent"]
   @Node_Key_Dir          = values["Key_Dir"]
+  @Consensus             = values["quorum"]["quorum"]["consensus"]
   return
 end
 

--- a/templates/k8s/quorum-keystore.yaml.erb
+++ b/templates/k8s/quorum-keystore.yaml.erb
@@ -10,9 +10,7 @@
 <%- @nodes.each do |node| -%>
 <%= set_node_template_vars(node) -%>
 
-# kubectl create configmap game-config --from-file=configure-pod-container/dd1/key
-# the key used for private transactions
-# quorum transaction manager keys
+# quorum transaction manager keys transaction manager key: used for private transactions.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -34,8 +32,7 @@ data:
 <% end -%>
 
 ---
-# kubectl create configmap game-config --from-file=configure-pod-container/dd1/key
-# nodekey (enode) (geth/ethereum)
+# nodekey private to the node, used to verify identity.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -51,8 +48,23 @@ data:
 <% end -%>
 
 ---
-# kubectl create configmap game-config --from-file=configure-pod-container/dd1/key
-# nodekey (enode) (geth/ethereum)
+# nodekey address public and used to generate istanbul-validator-config.toml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <%= @Node_UserIdent %>-nodekey-address-config
+    <%= @Namespace %>
+  labels:
+    app: qubernetes
+    name: <%= @Node_UserIdent %>-nodekey-address-config
+data:
+  nodekey: |
+      <%- File.readlines("#{@Key_Dir_Base}/#{@Node_Key_Dir}/nodekeyaddress").each do |line| -%>
+      <%= line -%>
+    <% end -%>
+
+---
+# enode Id
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -67,9 +79,8 @@ data:
     <%= line -%>
 <% end -%>
 
-# ethereum / geth account keys (keystore)
 ---
-# kubectl create configmap game-config --from-file=configure-pod-container/dd1/key
+# ethereum / geth account keys (keystore)
 # @Keystore_File=Dir[@Key_Dir_Base + "/" + @Node_Key_Dir + "/UTC*"][0]
 apiVersion: v1
 kind: ConfigMap

--- a/templates/k8s/quorum-keystore.yaml.erb
+++ b/templates/k8s/quorum-keystore.yaml.erb
@@ -47,6 +47,8 @@ data:
     <%= line -%>
 <% end -%>
 
+# Only IBFT / istanbul networks need access to the nodekey address.
+<%- if @Consensus == "istanbul" && File.file?("#{@Key_Dir_Base}/#{@Node_Key_Dir}/nodekeyaddress") -%>
 ---
 # nodekey address public and used to generate istanbul-validator-config.toml
 apiVersion: v1
@@ -62,6 +64,7 @@ data:
       <%- File.readlines("#{@Key_Dir_Base}/#{@Node_Key_Dir}/nodekeyaddress").each do |line| -%>
       <%= line -%>
     <% end -%>
+<%- end -%>
 
 ---
 # enode Id

--- a/templates/quorum/gen-keys.sh.erb
+++ b/templates/quorum/gen-keys.sh.erb
@@ -48,6 +48,8 @@ for node_key_dir in "${array[@]}"; do
     ethkey generate $KEY_DIR/acctkeyfile.json --passwordfile password.txt
     bootnode -genkey nodekey
     bootnode  -nodekeyhex $(cat nodekey) -writeaddress > enode
+    # save nodekey address (used for IBFT validator toml)
+    ethkey generate nodekeyacct.json --passwordfile password.txt --privatekey nodekey | sed 's/Address: //g' | sed 's/}//g' > nodekeyaddress
     popd
   else
     echo "Key Dir exists! Skipping creating new key in $KEY_DIR"

--- a/templates/quorum/gen-keys.sh.erb
+++ b/templates/quorum/gen-keys.sh.erb
@@ -48,8 +48,11 @@ for node_key_dir in "${array[@]}"; do
     ethkey generate $KEY_DIR/acctkeyfile.json --passwordfile password.txt
     bootnode -genkey nodekey
     bootnode  -nodekeyhex $(cat nodekey) -writeaddress > enode
-    # save nodekey address (used for IBFT validator toml)
+    # Only IBFT / istanbul networks need access to the nodekey address.
+<%- if @Consensus == "istanbul" -%>
+    # save nodekey address (used for istanbul-validator-config.toml)
     ethkey generate nodekeyacct.json --passwordfile password.txt --privatekey nodekey | sed 's/Address: //g' | sed 's/}//g' > nodekeyaddress
+<%- end -%>
     popd
   else
     echo "Key Dir exists! Skipping creating new key in $KEY_DIR"


### PR DESCRIPTION
When generating the nodekey address persist it, and set it in a configmap,
this is useful for cross cluster info as this is public and needs to be
shared when there is a cross cluster IBFT network.