### PR TITLE
[qctl] runCmd return error.

### DIFF
--- a/qctl/cakeshop.go
+++ b/qctl/cakeshop.go
@@ -35,7 +35,11 @@ var (
 
 			// get the current directory path, we'll use this in case the config file passed in was a relative path.
 			pwdCmd := exec.Command("pwd")
-			b := runCmd(pwdCmd)
+			b, err := runCmd(pwdCmd)
+			if err != nil {
+				red.Println(fmt.Sprintf(" Error executing command %s", pwdCmd))
+				log.Fatal(err)
+			}
 			pwd := strings.TrimSpace(b.String())
 
 			if configFile == "" {
@@ -123,7 +127,11 @@ var (
 			k8sdir := c.String("k8sdir")
 			// get the current directory path, we'll use this in case the config file passed in was a relative path.
 			pwdCmd := exec.Command("pwd")
-			b := runCmd(pwdCmd)
+			b, err := runCmd(pwdCmd)
+			if err != nil {
+				red.Println(fmt.Sprintf(" Error executing command %s", pwdCmd))
+				log.Fatal(err)
+			}
 			pwd := strings.TrimSpace(b.String())
 
 			if configFile == "" {

--- a/qctl/configcmd.go
+++ b/qctl/configcmd.go
@@ -67,16 +67,16 @@ var (
 				Usage: "additional geth startup params to run on the node.",
 			},
 			&cli.BoolFlag{
-				Name:  "monitor",
+				Name:    "monitor",
 				Aliases: []string{"monit"},
-				Usage: "enable monitoring on the geth / quorum node (prometheus).",
-				Value: false,
+				Usage:   "enable monitoring on the geth / quorum node (prometheus).",
+				Value:   false,
 			},
 			&cli.BoolFlag{
-				Name:  "cakeshop",
+				Name:    "cakeshop",
 				Aliases: []string{"cake"},
-				Usage: "deploy cakeshop with the Quorum network.",
-				Value: false,
+				Usage:   "deploy cakeshop with the Quorum network.",
+				Value:   false,
 			},
 			&cli.BoolFlag{
 				Name:  "ingress",
@@ -87,7 +87,7 @@ var (
 
 		Action: func(c *cli.Context) error {
 			pwdCmd := exec.Command("pwd")
-			b := runCmd(pwdCmd)
+			b, _ := runCmd(pwdCmd)
 			pwd := strings.TrimSpace(b.String())
 			// If the QUBE_CONFIG env is set or the flag passed in, use this file path and generate the config there.
 			// this is helpful when creating, deleting, networks repeatedly so that the config dirs can be set once and
@@ -237,7 +237,7 @@ var (
 		Action: func(c *cli.Context) error {
 
 			pwdCmd := exec.Command("pwd")
-			b := runCmd(pwdCmd)
+			b, _ := runCmd(pwdCmd)
 			pwd := strings.TrimSpace(b.String())
 
 			configFile := c.String("config")

--- a/qctl/monitor.go
+++ b/qctl/monitor.go
@@ -28,7 +28,7 @@ var (
 
 			// get the current directory path, we'll use this in case the config file passed in was a relative path.
 			pwdCmd := exec.Command("pwd")
-			b := runCmd(pwdCmd)
+			b, _ := runCmd(pwdCmd)
 			pwd := strings.TrimSpace(b.String())
 
 			if configFile == "" {
@@ -117,7 +117,7 @@ var (
 			k8sdir := c.String("k8sdir")
 			// get the current directory path, we'll use this in case the config file passed in was a relative path.
 			pwdCmd := exec.Command("pwd")
-			b := runCmd(pwdCmd)
+			b, _ := runCmd(pwdCmd)
 			pwd := strings.TrimSpace(b.String())
 
 			if configFile == "" {

--- a/qctl/networkcmd.go
+++ b/qctl/networkcmd.go
@@ -149,7 +149,7 @@ var (
 			qubernetesVersion := c.String("version")
 
 			pwdCmd := exec.Command("pwd")
-			b := runCmd(pwdCmd)
+			b, _ := runCmd(pwdCmd)
 			pwd := strings.TrimSpace(b.String())
 
 			// update / create

--- a/qctl/nodecmd.go
+++ b/qctl/nodecmd.go
@@ -71,7 +71,7 @@ var (
 			isHardDelete := c.Bool("hard")
 			// get the current directory path, we'll use this in case the config file passed in was a relative path.
 			pwdCmd := exec.Command("pwd")
-			b := runCmd(pwdCmd)
+			b, _ := runCmd(pwdCmd)
 			pwd := strings.TrimSpace(b.String())
 
 			if configFile == "" {
@@ -215,7 +215,7 @@ var (
 			configFile := c.String("config")
 			// get the current directory path, we'll use this in case the config file passed in was a relative path.
 			pwdCmd := exec.Command("pwd")
-			b := runCmd(pwdCmd)
+			b, _ := runCmd(pwdCmd)
 			pwd := strings.TrimSpace(b.String())
 
 			if configFile == "" {
@@ -355,7 +355,7 @@ var (
 
 			// get the current directory path, we'll use this in case the config file passed in was a relative path.
 			pwdCmd := exec.Command("pwd")
-			b := runCmd(pwdCmd)
+			b, _ := runCmd(pwdCmd)
 			pwd := strings.TrimSpace(b.String())
 
 			if configFile == "" {
@@ -516,7 +516,7 @@ var (
 
 			// get the current directory path, we'll use this in case the config file passed in was a relative path.
 			pwdCmd := exec.Command("pwd")
-			b := runCmd(pwdCmd)
+			b, _ := runCmd(pwdCmd)
 			pwd := strings.TrimSpace(b.String())
 
 			if configFile == "" {
@@ -726,7 +726,7 @@ var (
 
 			// get the current directory path, we'll use this in case the config file passed in was a relative path.
 			pwdCmd := exec.Command("pwd")
-			b := runCmd(pwdCmd)
+			b, _ := runCmd(pwdCmd)
 			pwd := strings.TrimSpace(b.String())
 
 			if configFile == "" {

--- a/qctl/testcmd.go
+++ b/qctl/testcmd.go
@@ -105,7 +105,7 @@ var (
 			k8sdir := c.String("k8sdir")
 			// get the current directory path, we'll use this in case the config file passed in was a relative path.
 			pwdCmd := exec.Command("pwd")
-			b := runCmd(pwdCmd)
+			b, _ := runCmd(pwdCmd)
 			pwd := strings.TrimSpace(b.String())
 
 			if configFile == "" {

--- a/qctl/utils.go
+++ b/qctl/utils.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -244,14 +243,11 @@ func runCmdQuiet(cmd *exec.Cmd) error {
 	return nil
 }
 
-func runCmd(cmd *exec.Cmd) bytes.Buffer {
+func runCmd(cmd *exec.Cmd) (bytes.Buffer, error) {
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err := cmd.Run()
-	if err != nil {
-		log.Fatal(err)
-	}
-	return out
+	return out, err
 }
 
 func fileExists(filename string) bool {


### PR DESCRIPTION
runCmd returns the error from executing the command instead of log.Fatal
and erroring out internally, so that the callers of the function can
handle the error as they like.