### PR TITLE
Basic multi-cluster support

### DIFF
--- a/qctl/nodecmd.go
+++ b/qctl/nodecmd.go
@@ -797,6 +797,10 @@ var (
 				fmt.Printf("config currently has %d nodes \n", currentNum)
 			}
 
+			if asExternal {
+				fmt.Println("external_nodes:")
+			}
+
 			for i := 0; i < len(configFileYaml.Nodes); i++ {
 				if nodeName == configFileYaml.Nodes[i].NodeUserIdent || nodeName == "" { // node name not set always show node
 					nodeFound = true

--- a/qctl/nodecmd.go
+++ b/qctl/nodecmd.go
@@ -654,11 +654,11 @@ var (
 			},
 			&cli.StringFlag{
 				Name:  "qimagefull",
-				Usage: "The full repo + image name of the quorum image.",
+				Usage: "The full repo + image name of the quorum image",
 			},
 			&cli.StringFlag{
 				Name:  "tmimagefull",
-				Usage: "The full repo + image name of the tm image.",
+				Usage: "The full repo + image name of the tm image",
 			},
 			&cli.BoolFlag{
 				Name:  "tmname",
@@ -681,6 +681,16 @@ var (
 				Name:    "gethparams",
 				Aliases: []string{"gp"},
 				Usage:   "display the geth startup params of the node",
+			},
+			&cli.BoolFlag{
+				Name:    "asexternal",
+				Aliases: []string{"asext"},
+				Usage:   "display information necessary for sending to another cluster for setup",
+			},
+			&cli.StringFlag{
+				Name:  "node-ip",
+				Usage: "the IP of the K8s node, e.g. minikube ip (used with asexternal).",
+				Value: "<K8s_NODE_IP>",
 			},
 			&cli.BoolFlag{
 				Name:    "bare",
@@ -708,6 +718,11 @@ var (
 			isAll := c.Bool("all")
 			isBare := c.Bool("bare")
 			k8sdir := c.String("k8sdir")
+			// display node info for external cluster.
+			asExternal := c.Bool("asexternal")
+			nodeip := c.String("node-ip")
+
+			configFile := c.String("config")
 			// set all values to true
 			if isAll {
 				isName = true
@@ -722,7 +737,6 @@ var (
 				isTmImageFull = true
 				isGethParams = true
 			}
-			configFile := c.String("config")
 
 			// get the current directory path, we'll use this in case the config file passed in was a relative path.
 			pwdCmd := exec.Command("pwd")
@@ -730,7 +744,7 @@ var (
 			pwd := strings.TrimSpace(b.String())
 
 			if configFile == "" {
-				c.App.Run([]string{"qctl", "help", "init"})
+				c.App.Run([]string{"qctl", "help", "node"})
 
 				// QUBE_CONFIG or flag
 				fmt.Println()
@@ -745,6 +759,18 @@ var (
 				green.Println("   qctl generate config")
 				fmt.Println()
 				return cli.Exit("--config flag must be set to the fullpath of your config file.", 3)
+			}
+
+			// the config file must exist or this is an error.
+			if fileExists(configFile) {
+				// check if config file is full path or relative path.
+				if !strings.HasPrefix(configFile, "/") {
+					configFile = pwd + "/" + configFile
+				}
+
+			} else {
+				c.App.Run([]string{"qctl", "help", "init"})
+				return cli.Exit(fmt.Sprintf("ConfigFile must exist! Given configFile [%v]", configFile), 3)
 			}
 			if !isBare {
 				fmt.Println()
@@ -761,17 +787,7 @@ var (
 				fmt.Println("*****************************************************************************************")
 				fmt.Println()
 			}
-			// the config file must exist or this is an error.
-			if fileExists(configFile) {
-				// check if config file is full path or relative path.
-				if !strings.HasPrefix(configFile, "/") {
-					configFile = pwd + "/" + configFile
-				}
 
-			} else {
-				c.App.Run([]string{"qctl", "help", "init"})
-				return cli.Exit(fmt.Sprintf("ConfigFile must exist! Given configFile [%v]", configFile), 3)
-			}
 			configFileYaml, err := LoadYamlConfig(configFile)
 			if err != nil {
 				log.Fatal("config file [%v] could not be loaded into the valid qubernetes yaml. err: [%v]", configFile, err)
@@ -782,18 +798,49 @@ var (
 			}
 
 			for i := 0; i < len(configFileYaml.Nodes); i++ {
-				if nodeName == "" { // node name not set always show node
-					if isBare { // show the bare version, cleaner for scripts.
-						displayNodeBare(k8sdir, configFileYaml.Nodes[i], isName, isKeyDir, isConsensus, isQuorumVersion, isTmName, isTmVersion, isEnodeUrl, isQuorumImageFull, isTmImageFull, isGethParams)
-					} else {
-						displayNode(k8sdir, configFileYaml.Nodes[i], isName, isKeyDir, isConsensus, isQuorumVersion, isTmName, isTmVersion, isEnodeUrl, isQuorumImageFull, isTmImageFull, isGethParams)
-					}
-				} else if nodeName == configFileYaml.Nodes[i].NodeUserIdent {
+				if nodeName == configFileYaml.Nodes[i].NodeUserIdent || nodeName == "" { // node name not set always show node
 					nodeFound = true
-					if isBare { // show the bare version, cleaner for scripts.
-						displayNodeBare(k8sdir, configFileYaml.Nodes[i], isName, isKeyDir, isConsensus, isQuorumVersion, isTmName, isTmVersion, isEnodeUrl, isQuorumImageFull, isTmImageFull, isGethParams)
+					if asExternal { // qctl ls nodes --asexternal -b --node-ip=$(minikube ip)
+
+						// qctl ls urls --node quorum-node1 --tm -bare
+						tmUrlCmd := exec.Command("qctl", "ls", "urls", "--node="+configFileYaml.Nodes[i].NodeUserIdent, "--type=nodeport", "--tm", "--bare", "--node-ip="+nodeip)
+						//fmt.Println(cmd.String())
+						res, err := runCmd(tmUrlCmd)
+						if err != nil {
+							log.Fatal(err)
+						}
+						tmurl := strings.TrimSpace(res.String())
+
+						p2pCmd := exec.Command("qctl", "ls", "urls", "--node="+configFileYaml.Nodes[i].NodeUserIdent, "--type=nodeport", "--p2p", "--bare", "--node-ip="+nodeip)
+						//fmt.Println(cmd.String())
+						res, err = runCmd(p2pCmd)
+						if err != nil {
+							log.Fatal(err)
+						}
+						p2pUrl := strings.TrimSpace(res.String())
+
+						// kc get configMap quorum-node1-nodekey-address-config -o jsonpath='{.data.nodekey}'
+						// try to get the node key address (ibft)
+						nodeKeyAddrCmd := exec.Command("kubectl", "get", "configMap",
+							configFileYaml.Nodes[i].NodeUserIdent+"-nodekey-address-config", "-o=jsonpath='{.data.nodekey}'")
+						res, err = runCmd(nodeKeyAddrCmd)
+						nodekeyAddress := ""
+						if err != nil && configFileYaml.Nodes[i].QuorumEntry.Quorum.Consensus == IstanbulConsensus {
+							red.Println(fmt.Sprintf(" issue getting the nodekey-address for node %s", configFileYaml.Nodes[i].NodeUserIdent))
+							red.Println(nodeKeyAddrCmd.String())
+							log.Fatal(err)
+						} else {
+							nodekeyAddress = strings.ReplaceAll(res.String(), "'", "")
+							nodekeyAddress = strings.TrimSpace(nodekeyAddress)
+						}
+						//fmt.Println("nodekeyAddress", nodekeyAddress)
+						displayNodeAsExternal(k8sdir, tmurl, nodekeyAddress, p2pUrl, configFileYaml.Nodes[i], true, isConsensus)
 					} else {
-						displayNode(k8sdir, configFileYaml.Nodes[i], isName, isKeyDir, isConsensus, isQuorumVersion, isTmName, isTmVersion, isEnodeUrl, isQuorumImageFull, isTmImageFull, isGethParams)
+						if isBare { // show the bare version, cleaner for scripts.
+							displayNodeBare(k8sdir, configFileYaml.Nodes[i], isName, isKeyDir, isConsensus, isQuorumVersion, isTmName, isTmVersion, isEnodeUrl, isQuorumImageFull, isTmImageFull, isGethParams)
+						} else {
+							displayNode(k8sdir, configFileYaml.Nodes[i], isName, isKeyDir, isConsensus, isQuorumVersion, isTmName, isTmVersion, isEnodeUrl, isQuorumImageFull, isTmImageFull, isGethParams)
+						}
 					}
 				}
 			}
@@ -836,7 +883,7 @@ func createNodeEntry(nodeName, nodeKeyDir, consensus, quorumVersion, txManager, 
 
 // QUBE_K8S_DIR
 // cat $QUBE_K8S_DIR/config/permissioned-nodes.json | grep quorum-node1
-func getEnodeId(nodeName, qubeK8sDir string) string {
+func getEnodeUrl(nodeName, qubeK8sDir string) string {
 	c1 := exec.Command("cat", qubeK8sDir+"/config/permissioned-nodes.json")
 	c2 := exec.Command("grep", nodeName)
 
@@ -884,7 +931,7 @@ func displayNode(k8sdir string, nodeEntry NodeEntry, name, consensus, keydir, qu
 		if k8sdir == "" {
 			red.Println("Set --k8sdir flag or QUBE_K8S_DIR env in order to display enodeurl")
 		} else {
-			enodeUrl := getEnodeId(nodeEntry.NodeUserIdent, k8sdir)
+			enodeUrl := getEnodeUrl(nodeEntry.NodeUserIdent, k8sdir)
 			if enodeUrl != "" {
 				green.Println(fmt.Sprintf("     [%s] enodeUrl: [%s]", nodeEntry.NodeUserIdent, enodeUrl))
 			}
@@ -925,13 +972,38 @@ func displayNodeBare(k8sdir string, nodeEntry NodeEntry, name, consensus, keydir
 		if k8sdir == "" {
 			red.Println("Set --k8sdir flag or QUBE_K8S_DIR env in order to display enodeurl")
 		} else {
-			enodeUrl := getEnodeId(nodeEntry.NodeUserIdent, k8sdir)
+			enodeUrl := getEnodeUrl(nodeEntry.NodeUserIdent, k8sdir)
 			fmt.Println(enodeUrl)
 		}
 	}
 	if isGethParms {
 		fmt.Println(nodeEntry.GethEntry.GetStartupParams)
 	}
+}
+
+func displayNodeAsExternal(k8sdir string, tmurl string, nodekeyAddress string, p2pUrl string, nodeEntry NodeEntry, name, consensus bool) {
+	if name {
+		fmt.Println("- Node_UserIdent: ", nodeEntry.NodeUserIdent)
+	}
+	if consensus {
+		fmt.Println(nodeEntry.QuorumEntry.Quorum.Consensus)
+	}
+	fmt.Println("  Tm_Url: ", tmurl)
+	// need the tm URL that is addressable from outside the cluster (ingress or nodeport).
+	// need the enodeURL of the node, that is addressable from outside the cluster (ingress or nodeport).
+	if k8sdir == "" {
+		red.Println("Set --k8sdir flag or QUBE_K8S_DIR env in order to display enodeurl")
+	} else {
+		enodeUrl := getEnodeUrl(nodeEntry.NodeUserIdent, k8sdir)
+		// replace the internal dns addressable p2p @quorum-node1:30303? with an external p2p URL (nodeport)
+		enodeUrl = strings.ReplaceAll(enodeUrl, nodeEntry.NodeUserIdent+":"+DefaultP2PPort, p2pUrl)
+		fmt.Println("  Enode_Url:", enodeUrl)
+	}
+	// if IBFT need the Node_Acct_Addr
+	if nodekeyAddress != "" {
+		fmt.Println("  Node_Acct_Addr:", "\""+nodekeyAddress+"\"")
+	}
+	// Acct_PubKey??
 }
 
 // stop node should just remove the deployment, and not delete any resources or persistent data.

--- a/quorum-config
+++ b/quorum-config
@@ -58,7 +58,7 @@ end
 
 @config     = YAML.load_file(@config_file)
 @nodes      = @config["nodes"] #YAML.load_file("nodes.yaml")["nodes"]
-
+@external_nodes = @config["external_nodes"]
 ## set defaults for config if not set, else use the values from the config.
 
 # used by quorum-shared-config.yaml.erb and quorum-keystore.yaml.erb to load keys.

--- a/quorum-init
+++ b/quorum-init
@@ -57,6 +57,7 @@ if File.directory?("out") && (action == 'ask')
     createNew=true
   when "2"
     puts("Generating additional resources only.")
+    action = 'update'
   when "3"
     puts("OK, bye :)")
     exit(0)

--- a/templates/quorum/istanbul-validator.toml.erb
+++ b/templates/quorum/istanbul-validator.toml.erb
@@ -25,4 +25,9 @@ validators = [
     end
   end
 -%>
+<%- if  @external_nodes -%>
+<%-  @external_nodes.each do |extnode| -%>
+"<%=extnode["Node_Acct_Addr"] %>",
+<%- end -%>
+<%- end -%>
 ]

--- a/templates/quorum/permissioned-nodes.json.erb
+++ b/templates/quorum/permissioned-nodes.json.erb
@@ -14,6 +14,12 @@ end
   <%- @Enode_File = @Key_Dir_Base + "/" + @Node_Key_Dir + "/enode" -%>
   <%- File.readlines(@Enode_File).each do |line| @Enode = "#{line}".gsub(/\s+/, "") end -%>
   <%- # use the service name / kube-dns to look up the nodes -%>
-  "enode://<%= @Enode %>@<%= "#{@Node_UserIdent}"%>:<%= @NodeP2P_ListenAddr%>?discport=0&raftport=<%= @Raft_Port%>"<%- if (indexNode != @nodes.size - 1) %>,<%- end %>
+  "enode://<%= @Enode %>@<%= "#{@Node_UserIdent}"%>:<%= @NodeP2P_ListenAddr%>?discport=0&raftport=<%= @Raft_Port%>"<%- if (indexNode != @nodes.size - 1) || (@external_nodes && @external_nodes.size != 0) %>,<%- end %>
   <% end -%>
+  <%- if  @external_nodes -%>
+  <%- @external_nodes.each_with_index do |extnode, indexNode| -%>
+  "<%= extnode["Enode_Url"] %>"<%- if (indexNode != @external_nodes.size - 1) %>,<%- end %>
+  <% end -%>
+  <%- end -%>
+
 ]

--- a/templates/quorum/tessera-config-9.0.json.erb
+++ b/templates/quorum/tessera-config-9.0.json.erb
@@ -71,9 +71,16 @@ end
 <%= set_node_template_vars(node) -%>
      {
            "url": "http://<%= @Node_UserIdent %>:<%= @Tm_Port %>"
-         }<%- if (indexNode != @nodes.size - 1) %>,<%- end %>
+         }<%- if (indexNode != @nodes.size - 1) || (@external_nodes && @external_nodes.size != 0) %>,<%- end %>
 
 <% end -%>
+<%- if  @external_nodes -%>
+<%- @external_nodes.each_with_index do |extnode, indexNode| %>
+     {
+      "url": "http://<%= extnode["Tm_Url"]%>"
+     }<%- if (indexNode != @external_nodes.size - 1) %>,<%- end %>
+<%- end -%>
+<%- end -%>
     ],
     "keys": {
          "passwords": [],

--- a/templates/quorum/tessera-config-enhanced.json.erb
+++ b/templates/quorum/tessera-config-enhanced.json.erb
@@ -74,9 +74,16 @@ end
 <%= set_node_template_vars(node) -%>
      {
            "url": "http://<%= @Node_UserIdent %>:<%= @Tm_Port %>"
-         }<%- if (indexNode != @nodes.size - 1) %>,<%- end %>
+         }<%- if (indexNode != @nodes.size - 1) || (@external_nodes && @external_nodes.size != 0) %>,<%- end %>
 
 <% end -%>
+<%- if  @external_nodes -%>
+<%- @external_nodes.each_with_index do |extnode, indexNode| %>
+     {
+       "url": "http://<%= extnode["Tm_Url"]%>"
+     }<%- if (indexNode != @external_nodes.size - 1) %>,<%- end %>
+<%- end -%>
+<%- end -%>
     ],
     "keys": {
          "passwords": [],

--- a/templates/quorum/tessera-config.json.erb
+++ b/templates/quorum/tessera-config.json.erb
@@ -47,9 +47,16 @@ end
     <%= set_node_template_vars(node) -%>
      {
            "url": "http://<%= @Node_UserIdent%>:<%= @Tm_Port %>"
-         }<%- if (indexNode != @nodes.size - 1) %>,<%- end %>
+         }<%- if (indexNode != @nodes.size - 1) || (@external_nodes && @external_nodes.size != 0) %>,<%- end %>
 
-<% end -%>
+<%- end -%>
+<%- if  @external_nodes -%>
+<%- @external_nodes.each_with_index do |extnode, indexNode| %>
+         {
+             "url": "http://<%= extnode["Tm_Url"]%>"
+         }<%- if (indexNode != @external_nodes.size - 1) %>,<%- end %>
+<%- end -%>
+<%- end -%>
     ],
     "keys": {
         "passwords": [],


### PR DESCRIPTION
Initial support for running a quorum k8s network across multiple clusters.

To run a multi-cluster Quorum k8s network, a quorum network must initially be started in a single cluster and the `genesis.json` needs to be shared with all other cluster that wish to connect. 

There is a new (optional) entry in the qubernetes config `external-nodes`, e.g.
```
external_nodes:
  - Node_UserIdent:  quorum-node1
    Tm_Url:  192.168.64.49:30853
    Enode_Url: "enode://e6ccd013b90e17ea7692905609f2a8a7922d855ebcb4476f1afc6aa4ad4261a2af40df9f1b6f4c6a83c96fd40bbad4d63352047d890a278d6cd410a225a1a236@192.168.64.49:31500?discport=0&raftport=50401"
    Node_Acct_Addr: "0xC7868aA6C261aAaDA3E370315B6CF752056F54d1"
  - Node_UserIdent:  quorum-node2
    Tm_Url:  192.168.64.49:31680
```
This is the information that a cluster needs to connect to another cluster. There is a `qctl` command to obtain this info from inside a cluster, e.g. `qctl ls nodes --asexternal -b --node-ip=$(minikube ip)` 

If cluster A (C-A) wishes to add nodes from cluster B (C-B), C-A must:

1.   Obtain its running node information as an external node,  e.g. `qctl ls nodes --asexternal -b --node-ip=$(minikube ip)`  and give this it C-A. 
2. C-A must add C-B's `external_node` info to its qubernetes config and generate the appropriate resources, `qctl generate network --update`.  
3. Once C-A has been deploy, C-A must do the same: obtain the external_nodes info for its running nodes, and share that with C-B. 
4. When C-B has updated its qubernetes config with C-A external_nodes and redeployed, the nodes should be able to connect.

* note: currently only supporting NodePort so the external_node info must be obtained from a running cluster, and note the NodePort may change if the node goes down.
* todo: Ingress support should be implemented next, so that the `external_node` info will node change. 