### PR TITLE
support for qibft consensus.

### DIFF
--- a/qctl/configcmd.go
+++ b/qctl/configcmd.go
@@ -33,16 +33,21 @@ var (
 				Value: DefaultConesensus,
 			},
 			&cli.StringFlag{
+				Name:  "qibftblock",
+				Usage: "Blocknumber at which the network will switch over from ibft to qibft.",
+				Value: "0",
+			},
+			&cli.StringFlag{
 				Name:    "qversion",
 				Aliases: []string{"qv"},
-				Value:   DefaultQuorumVersion,
 				Usage:   "Quorum Version.",
+				Value:   DefaultQuorumVersion,
 			},
 			&cli.StringFlag{
 				Name:    "tmversion",
 				Aliases: []string{"tmv"},
-				Value:   DefaultTesseraVersion,
 				Usage:   "transaction Manager Version.",
+				Value:   DefaultTesseraVersion,
 			},
 			&cli.StringFlag{
 				Name:  "tm",
@@ -105,6 +110,7 @@ var (
 			tmVersion := c.String("tmversion")
 			transactionManager := c.String("tm")
 			consensus := c.String("consensus")
+			qibftblock := c.String("qibftblock")
 			chainId := c.String("chainid")
 			qimagefull := c.String("qimagefull")
 			tmImageFull := c.String("tmimagefull")
@@ -152,6 +158,9 @@ var (
 
 			configYaml.Genesis.QuorumVersion = quorumVersion
 			configYaml.Genesis.Consensus = consensus
+			if consensus == "qibft" { // if --qibftblock=BLOCK_NUM not specified set to default block 0, else the user can specify --qibftblock=BLOCK_NUM
+				configYaml.Genesis.QibftBlock = qibftblock
+			}
 			configYaml.Genesis.Chain_Id = chainId
 
 			if isMonitoring {

--- a/qctl/configyaml.go
+++ b/qctl/configyaml.go
@@ -13,6 +13,7 @@ var (
     genesis:
       # supported: (raft | istanbul)
       consensus: istanbul
+      qibftBlock: 0 
       Quorum_Version: 2.6.0
       Chain_Id: 1000
     nodes:
@@ -31,13 +32,13 @@ type GethEntry struct {
 type Quorum struct {
 	Consensus      string `yaml:"consensus"`
 	QuorumVersion  string `yaml:"Quorum_Version"`
-	DockerRepoFull string `yaml:"Docker_Repo_Full"` //quorum-local:latest
+	DockerRepoFull string `yaml:"Docker_Repo_Full,omitempty"` //quorum-local
 }
 
 type Tm struct {
 	Name           string `yaml:"Name"`
 	TmVersion      string `yaml:"Tm_Version"`
-	DockerRepoFull string `yaml:"Docker_Repo_Full"` //tessera-local:latest
+	DockerRepoFull string `yaml:"Docker_Repo_Full,omitempty"` //tessera-local
 }
 
 type NodeEntry struct {
@@ -78,6 +79,7 @@ type K8s struct {
 type QConfig struct {
 	Genesis struct {
 		Consensus     string `yaml:"consensus"`
+		QibftBlock    string `yaml:"qibftBlock,omitempty"`
 		QuorumVersion string `yaml:"Quorum_Version"`
 		Chain_Id      string `yaml:"Chain_Id"`
 	}

--- a/qctl/nodecmd.go
+++ b/qctl/nodecmd.go
@@ -925,10 +925,10 @@ func displayNode(k8sdir string, nodeEntry NodeEntry, name, consensus, keydir, qu
 	if tmVersion {
 		green.Println(fmt.Sprintf("     [%s] tmVersion: [%s]", nodeEntry.NodeUserIdent, nodeEntry.QuorumEntry.Tm.TmVersion))
 	}
-	if isQuorumImageFull {
+	if isQuorumImageFull && nodeEntry.QuorumEntry.Quorum.DockerRepoFull != "" {
 		green.Println(fmt.Sprintf("     [%s] quorumImage: [%s]", nodeEntry.NodeUserIdent, nodeEntry.QuorumEntry.Quorum.DockerRepoFull))
 	}
-	if isTmImageFull {
+	if isTmImageFull && nodeEntry.QuorumEntry.Tm.DockerRepoFull != "" {
 		green.Println(fmt.Sprintf("     [%s] tmImage: [%s]", nodeEntry.NodeUserIdent, nodeEntry.QuorumEntry.Tm.DockerRepoFull))
 	}
 	if isEnodeUrl {
@@ -941,7 +941,7 @@ func displayNode(k8sdir string, nodeEntry NodeEntry, name, consensus, keydir, qu
 			}
 		}
 	}
-	if isGethParms {
+	if isGethParms && nodeEntry.GethEntry.GetStartupParams != "" {
 		green.Println(fmt.Sprintf("     [%s] geth params: [%s]", nodeEntry.NodeUserIdent, nodeEntry.GethEntry.GetStartupParams))
 	}
 	fmt.Println()

--- a/templates/k8s/quorum-deployment.yaml.erb
+++ b/templates/k8s/quorum-deployment.yaml.erb
@@ -231,7 +231,7 @@ spec:
            <%-# --raftdnsenable is need for adding additional nodes with hostnames. Without this node the network will start up fine, but adding nodes with enode host name URL will fail. -%>
            args=\" --gcmode archive --raft  --raftport <%= @Raft_Port %> --raftdnsenable \";
            RPC_APIS=\"$RPC_APIS,raft\";
-         <%- elsif @Consensus == "istanbul" -%>
+         <%- elsif @Consensus == "istanbul" || @Consensus == "qibft" -%>
            args=\" --gcmode archive --istanbul.blockperiod 3 --syncmode full --mine --minerthreads 1 \";
            RPC_APIS=\"$RPC_APIS,istanbul\";
          <%- end -%>
@@ -313,7 +313,7 @@ spec:
           mountPath: <%= @Node_DataDir%>/permission-nodes
         - name: geth-helpers
           mountPath: /geth-helpers
-        <%- if @Consensus == "istanbul" -%>
+        <%- if @Consensus == "istanbul" || @Consensus == "qibft" -%>
         - name: istanbul-validator-config
           mountPath: <%= @Node_DataDir%>/istanbul-validator-config.toml
         - name: node-management
@@ -389,7 +389,7 @@ spec:
             - key: geth-exec.sh
               path: geth-exec.sh
           defaultMode: 0777
-      <%- if @Consensus == "istanbul" -%>
+      <%- if @Consensus == "istanbul" || @Consensus == "qibft" -%>
       - name: istanbul-validator-config
         configMap:
           name: istanbul-validator-config.toml

--- a/templates/k8s/quorum-keystore.yaml.erb
+++ b/templates/k8s/quorum-keystore.yaml.erb
@@ -48,7 +48,7 @@ data:
 <% end -%>
 
 # Only IBFT / istanbul networks need access to the nodekey address.
-<%- if @Consensus == "istanbul" && File.file?("#{@Key_Dir_Base}/#{@Node_Key_Dir}/nodekeyaddress") -%>
+<%- if (@Consensus == "istanbul" || @Consensus == "qibft") && File.file?("#{@Key_Dir_Base}/#{@Node_Key_Dir}/nodekeyaddress") -%>
 ---
 # nodekey address public and used to generate istanbul-validator-config.toml
 apiVersion: v1

--- a/templates/k8s/quorum-shared-config.yaml.erb
+++ b/templates/k8s/quorum-shared-config.yaml.erb
@@ -89,7 +89,7 @@ data:
     <% end -%>
 <%- end -%>
 ## include ibft helpers as we don't know which nodes will be running which consensus.
-<%- if @config["genesis"]["consensus"] == "istanbul" -%>
+<%- if @config["genesis"]["consensus"] == "istanbul" || @config["genesis"]["consensus"] == "qibft" -%>
 
 ---
 apiVersion: v1

--- a/templates/quorum/gen-keys.sh.erb
+++ b/templates/quorum/gen-keys.sh.erb
@@ -49,7 +49,7 @@ for node_key_dir in "${array[@]}"; do
     bootnode -genkey nodekey
     bootnode  -nodekeyhex $(cat nodekey) -writeaddress > enode
     # Only IBFT / istanbul networks need access to the nodekey address.
-<%- if @Consensus == "istanbul" -%>
+<%- if @Consensus == "istanbul" || @Consensus == "qibft" -%>
     # save nodekey address (used for istanbul-validator-config.toml)
     ethkey generate nodekeyacct.json --passwordfile password.txt --privatekey nodekey | sed 's/Address: //g' | sed 's/}//g' > nodekeyaddress
 <%- end -%>

--- a/templates/quorum/genesis.json.erb
+++ b/templates/quorum/genesis.json.erb
@@ -11,6 +11,11 @@ if @config["genesis"] and @config["genesis"]["Chain_Id"]
 end
 ## The genesis consensus and the quorum version must be set in the config file.
 @Genesis_Consensus = @config["genesis"]["consensus"]
+# if the qibftblock is set, the network will switch over to qibft consensus
+# when the specified block number is reached.
+if @config["genesis"]["qibftBlock"]
+  @Qibft_Block = @config["genesis"]["qibftBlock"]
+end
 @Genesis_Quorum_Version = @config["genesis"]["Quorum_Version"]
 
 @Account_Allocs = ""
@@ -82,7 +87,7 @@ end
   "parenthash": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "timestamp": "0x00"
 }
-<% elsif @Genesis_Consensus == "istanbul" %>
+<% elsif @Genesis_Consensus == "istanbul" ||  @Genesis_Consensus == "qibft" %>
 {
 "alloc": {
 <%- @nodes.each_with_index do |node, indexNode|
@@ -123,6 +128,9 @@ end
     "eip155Block": 0,
     "eip158Block": 0,
     "istanbul": {
+      <%- if @Qibft_Block -%>
+      "qibftBlock": <%= @Qibft_Block %>,
+      <%- end -%>
       "epoch": 30000,
       "policy": 0
     },


### PR DESCRIPTION
* a Quorum qibft branch must be built locally, or obtained from a docker repo.
* qubernetes docker image support added for generating compatible quorum
and k8s resources for qibft.
* qctl support for generating a qubernetes config to support qibft.
e.g. if branch quorum-updated_ibft image built locally:
qctl init --consensus=qibft --qimagefull=quorum-updated_ibft

see: https://github.com/ConsenSys/qubernetes/tree/master/qctl/local-dev
for building and running images locally.