### PR TITLE
[qctl] support external nodes

### DIFF
--- a/qctl/configyaml.go
+++ b/qctl/configyaml.go
@@ -48,6 +48,13 @@ type NodeEntry struct {
 	GethEntry     GethEntry   `yaml:"geth"`
 }
 
+type ExternalNodeEntry struct {
+	NodeUserIdent  string `yaml:"Node_UserIdent"`
+	EnodeUrl       string `yaml:"Enode_Url"`
+	TmUrl          string `yaml:"Tm_Url"`
+	NodekeyAddress string `yaml:"Node_Acct_Addr,omitempty"`
+}
+
 type Prometheus struct {
 	//#monitor_params_geth: --metrics --metrics.expensive --pprof --pprofaddr=0.0.0.0
 	//monitorParamsGeth string `yaml:"monitor_params_geth"`
@@ -87,7 +94,8 @@ type QConfig struct {
 	Cakeshop   Cakeshop   `yaml:"cakeshop,omitempty"`
 	K8s        K8s        `yaml:"k8s,omitempty"`
 
-	Nodes []NodeEntry
+	Nodes         []NodeEntry
+	ExternalNodes []ExternalNodeEntry `yaml:"external_nodes,omitempty"`
 }
 
 func GetYamlConfig() QConfig {

--- a/qctl/configyaml.go
+++ b/qctl/configyaml.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 var (
@@ -49,9 +49,13 @@ type NodeEntry struct {
 }
 
 type ExternalNodeEntry struct {
-	NodeUserIdent  string `yaml:"Node_UserIdent"`
-	EnodeUrl       string `yaml:"Enode_Url"`
-	TmUrl          string `yaml:"Tm_Url"`
+	NodeUserIdent string `yaml:"Node_UserIdent"`
+	EnodeUrl      string `yaml:"Enode_Url"`
+	TmUrl         string `yaml:"Tm_Url"`
+	// must be set in the yaml without quotes.
+	// The hex number will be evaluted to a BigNum and
+	// template/istanbul-validator.toml.erb will convert back to hex
+	// https://github.com/mikefarah/yq/issues/19
 	NodekeyAddress string `yaml:"Node_Acct_Addr,omitempty"`
 }
 

--- a/qctl/networkcmd.go
+++ b/qctl/networkcmd.go
@@ -16,7 +16,7 @@ var (
 		Usage: "delete a quorum k8s network given the dir holding the k8s yaml resources.",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:     "k8s-dir",
+				Name:     "k8sdir",
 				Usage:    "the path of the dir containing the K8s resource yaml.",
 				EnvVars:  []string{"QUBE_K8S_DIR"},
 				Required: true,
@@ -32,7 +32,7 @@ var (
 		Usage: "create a quorum k8s network given the dir holding the k8s yaml resources.",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:     "k8s-dir",
+				Name:     "k8sdir",
 				Usage:    "the path of the dir containing the K8s resource yaml.",
 				EnvVars:  []string{"QUBE_K8S_DIR"},
 				Required: true,
@@ -74,7 +74,7 @@ var (
 		Usage: "list the status of the running network.",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:     "k8s-dir",
+				Name:     "k8sdir",
 				Usage:    "the path of the dir containing the K8s resource yaml.",
 				EnvVars:  []string{"QUBE_K8S_DIR"},
 				Required: true,
@@ -294,10 +294,10 @@ var (
 )
 
 func k8sCreateDeleteCluster(c *cli.Context, action string) error {
-	k8sdir := c.String("k8s-dir")
+	k8sdir := c.String("k8sdir")
 	// if the passed in k8s dir does not exit, tell the user and do not proceed.
 	if _, err := os.Stat(k8sdir); os.IsNotExist(err) {
-		log.Error("the --k8s-dir [%v] does not exist!", k8sdir)
+		log.Error("the --k8sdir [%v] does not exist!", k8sdir)
 		return err
 	}
 	namespace := c.String("namespace")

--- a/qctl/qctl.go
+++ b/qctl/qctl.go
@@ -95,6 +95,7 @@ func main() {
 			Usage:   "options for listing resources",
 			Subcommands: []*cli.Command{
 				&nodeListCommand,
+				&externalNodeListCommand,
 				&allListCommand,
 				&urlGetCommand,
 				&describeConfigCommand,

--- a/qctl/qctl.go
+++ b/qctl/qctl.go
@@ -108,6 +108,7 @@ func main() {
 			Usage: "options for adding resources",
 			Subcommands: []*cli.Command{
 				&nodeAddCommand,
+				&externalNodeAddCommand,
 				&cakeshopAddCommand,
 				&monitorAddCommand,
 			},

--- a/qctl/qctl.go
+++ b/qctl/qctl.go
@@ -54,6 +54,7 @@ func main() {
 				&networkDeleteCommand,
 				// TODO: Think this through a bit, hard delete vs soft delete, etc.
 				&nodeDeleteCommand,
+				&externalNodeDeleteCommand,
 				&cakeshopDeleteCommand,
 				&monitorDeleteCommand,
 			},

--- a/templates/quorum/istanbul-validator.toml.erb
+++ b/templates/quorum/istanbul-validator.toml.erb
@@ -26,8 +26,21 @@ validators = [
   end
 -%>
 <%- if  @external_nodes -%>
-<%-  @external_nodes.each do |extnode| -%>
-"<%=extnode["Node_Acct_Addr"] %>",
+<%-  @external_nodes.each do |extnode|
+ # this is to get around a yaml parsing issue, qctl uses github.com/urfave/cli/v2 which does not preserve double quotes,
+ # and if a hex value is stored in yaml without it will be evaluated to a Bignum, Node_Acct_Addr must be set as hex numbers
+ # without quotes, e.g.0xDEe962299b55dA670fC70702e626ac9009AE3aC7, and then converted back to hex here.
+   nodekeyAddr = extnode["Node_Acct_Addr"]
+   # check if the nodekey address is not a hex string, if not we assume it has been converted to a BigNum
+   # and convert it back to a hex.
+   nodekeyAddrStr = nodekeyAddr.to_s
+   if nodekeyAddrStr[0..1] != "0x"
+    nodekeyAddr = nodekeyAddr.to_s(16)
+    nodekeyAddr = "0x" + nodekeyAddr
+   end
+   puts("external node account for Istanbul: " + nodekeyAddr)
+ -%>
+"<%=nodekeyAddr %>",
 <%- end -%>
 <%- end -%>
 ]


### PR DESCRIPTION
* add external_nodes to configyaml used by qctl, so qctl can interact with it, 
   e.g. add, delete, ls
* add support for listing the external nodes in a network:
    > qctl ls extnodes --all
* add support for adding an external node:
  > qctl add extnode --enode="enode://12343@1.2.3.4:7000" --tmurl=http://1.2.3.4:9000  --nodekeyaddr=0x1234334
*  add support deleting external nodes:
    >  qctl delete external-node
* allow the external_node `Node_Acct_Addr` field to be set to a hex without quotes
   or a string hex in the qubernetes yaml. If it is set as a hex without quotes, the hex value will 
   be converted to a BigNum, cover both cases in `istanbul-validator.toml.erb`. 
   the yaml parser (https://godoc.org/gopkg.in/yaml.v2) used does not preserve double 
   quotes around the hex  https://github.com/mikefarah/yq/issues/19