### PR TITLE
pad nodekey addr with 0s to get addr constant sz.

### DIFF
--- a/qctl/nodecmd.go
+++ b/qctl/nodecmd.go
@@ -257,7 +257,7 @@ var (
 			fmt.Printf("config currently has %d external nodes \n", currentNum)
 			fmt.Println()
 			var nodeToDelete ExternalNodeEntry
-			for i := 0; i <= len(configFileYaml.ExternalNodes); i++ {
+			for i := 0; i < len(configFileYaml.ExternalNodes); i++ {
 				//displayNode(k8sdir, configFileYaml.Nodes[i], isName, isKeyDir, isConsensus, isQuorumVersion, isTmName, isTmVersion, isEnodeUrl, isQuorumImageFull)
 				if configFileYaml.ExternalNodes[i].NodeUserIdent == nodeName {
 					nodeToDelete = configFileYaml.ExternalNodes[i]

--- a/templates/quorum/istanbul-validator.toml.erb
+++ b/templates/quorum/istanbul-validator.toml.erb
@@ -35,7 +35,9 @@ validators = [
    # and convert it back to a hex.
    nodekeyAddrStr = nodekeyAddr.to_s
    if nodekeyAddrStr[0..1] != "0x"
-    nodekeyAddr = nodekeyAddr.to_s(16)
+    # need a hexicdemical of length 40 (pad with leading 0s)
+    # 0x078426792F49BF76A94CFD2A1A35EBE8832DE3F1 vs 0x78426792F49BF76A94CFD2A1A35EBE8832DE3F1
+    nodekeyAddr = "%040X" % nodekeyAddr
     nodekeyAddr = "0x" + nodekeyAddr
    end
    puts("external node account for Istanbul: " + nodekeyAddr)


### PR DESCRIPTION
when converting the nodekey addr from integer to hexidecimal, we need to
pad the hex with leading 0s to get a constant address length of 40 hex
chars.