### PR TITLE
[qctl] use namespace with network / test command.

### DIFF
--- a/qctl/networkcmd.go
+++ b/qctl/networkcmd.go
@@ -50,6 +50,7 @@ var (
 		},
 		Action: func(c *cli.Context) error {
 			wait := c.Bool("wait")
+			namespace := c.String("namespace")
 			var configFileYaml QConfig
 			if wait { // if the wait flag is set, the qubernetes flag / env var is required, to check the status of the network.
 				config := c.String("config")
@@ -64,7 +65,7 @@ var (
 				return cli.Exit(fmt.Sprintf("Error while trying to create k8s cluster [%v]", err), 3)
 			}
 			if wait {
-				waitForPodsReadyState(configFileYaml)
+				waitForPodsReadyState(configFileYaml, namespace)
 			}
 			return nil
 		},
@@ -88,11 +89,12 @@ var (
 		},
 		Action: func(c *cli.Context) error {
 			config := c.String("config")
+			namespace := c.String("namespace")
 			configFileYaml, err := LoadYamlConfig(config)
 			if err != nil {
 				log.Fatal("config file [%v] could not be loaded into the valid qubernetes yaml. err: [%v]", config, err)
 			}
-			waitForPodsReadyState(configFileYaml)
+			waitForPodsReadyState(configFileYaml, namespace)
 			return nil
 		},
 	}

--- a/qctl/testcmd.go
+++ b/qctl/testcmd.go
@@ -40,7 +40,7 @@ var (
 				return cli.Exit("wrong number of arguments", 2)
 			}
 			nodeName := c.Args().First()
-			namespace := ""
+			namespace := c.String("namespace")
 			podName := podNameFromPrefix(nodeName, namespace)
 			fmt.Println(fmt.Sprintf("running test contract(s) on node [%s] pod [%s]", nodeName, podName))
 

--- a/qctl/utils.go
+++ b/qctl/utils.go
@@ -259,7 +259,7 @@ func fileExists(filename string) bool {
 	return !info.IsDir()
 }
 
-func waitForPodsReadyState(qconfigYaml QConfig) {
+func waitForPodsReadyState(qconfigYaml QConfig, namespace string) {
 	nodeNames := getNodeNames(qconfigYaml)
 	allContainersReady := false
 	nodeNotDeployed := false
@@ -281,12 +281,11 @@ func waitForPodsReadyState(qconfigYaml QConfig) {
 		// loop through this till 2/2 RUNNING is true for all nodes in the config file.
 		// if any pod doesn't have both containers running break, set to false, wait and loop again.
 		for i := 0; i < len(nodeNames); i++ {
-			podName := podNameFromPrefix(nodeNames[i], "")
-
+			podName := podNameFromPrefix(nodeNames[i], namespace)
 			// get the full pod status for the current pod, e.g.:
 			// NAME                                READY   STATUS    RESTARTS   AGE
 			// node5-deployment-54d7d99575-ztgbv   2/2     Running   0          9h
-			c1 := exec.Command("kubectl", "get", "pod", podName)
+			c1 := exec.Command("kubectl", "--namespace="+namespace, "get", "pod", podName)
 			// get the pod status part only ignoring the header, e.g.:
 			// node5-deployment-54d7d99575-ztgbv   2/2     Running   0          9h
 			c2 := exec.Command("grep", podName)


### PR DESCRIPTION
Use the namespace flag or env var QUORUM_NAMESPACE (if set) when running
the `qctl test contract` command and the `qctl create network` command.