### PR TITLE
Allow single node deployments.

### DIFF
--- a/templates/k8s/quorum-shared-config.yaml.erb
+++ b/templates/k8s/quorum-shared-config.yaml.erb
@@ -52,15 +52,15 @@ data:
 <%- File.readlines("contracts/runscript.sh").each do |line| -%>
     <%= line -%>
 <% end -%>
-# set the tm.pub for node2 in the privateFor field.
-# assumes that at least 2 nodes are being deployed.
+# set the tm.pub for node1 in the privateFor field.
+# supports single node deployment.
   private_contract.js: |-
-<%-  tm_key2 = "NOT_SET" -%>
-<%- File.readlines("#{@Key_Dir_Base}/key2/tm.pub").each do |line| -%>
-<% tm_key2 = line %>
+<%-  tm_key1 = "NOT_SET" -%>
+<%- File.readlines("#{@Key_Dir_Base}/key1/tm.pub").each do |line| -%>
+<% tm_key1 = line %>
 <% end -%>
 <%- File.readlines("contracts/private_contract.js").each do |line| -%>
-    <%- with_valid_key = line.gsub(/"%PRIVATE_FOR_NODE%"/, '"' + tm_key2 + '"') -%>
+    <%- with_valid_key = line.gsub(/"%PRIVATE_FOR_NODE%"/, '"' + tm_key1 + '"') -%>
     <%= with_valid_key -%>
 <% end -%>
   public_contract.js: |-

--- a/testing/test-k8s-resources.sh
+++ b/testing/test-k8s-resources.sh
@@ -153,7 +153,7 @@ done
 
 printf "${GREEN}Total Successful networks: ${SUCCESS}${NC}\n"
 printf "${RED}Total Failed networks: ${FAILURES}${NC}\n"
-printf "${RED}Failed runds: ${FAILED_RUNS}${NC}\n"
+printf "${RED}Failed runs: ${FAILED_RUNS}${NC}\n"
 if [[ $FAILURES -ne 0 ]]; then
   exit 1
 fi


### PR DESCRIPTION
As per issue: https://github.com/ConsenSys/qubernetes/issues/99
single node deployments may be useful for testing, etc.

When setting up the private test contract, use the node key of node1
instead of node2 which does not exist in a single node deployment.

> qctl init --num 1
> qctl generate network --create
> qctl deploy network