### PR TITLE
Use wget instead of curl for transaction manager check

### DIFF
--- a/7nodes/clique-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node1-quorum-deployment.yaml
+++ b/7nodes/clique-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node1-quorum-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       securityContext:
       initContainers:
       - name: quorum-genesis-init-container
-        image: quorumengineering/quorum:2.5.0
+        image: quorumengineering/quorum:20.10.0
         command: [ "sh" ]
         args:
         - "-cx"
@@ -58,7 +58,7 @@ spec:
           readOnly: false
       containers:
       - name: tessera
-        image: quorumengineering/tessera:0.10.4
+        image: quorumengineering/tessera:20.10.0
         command: ["sh"]
         args:
         - "-cx"
@@ -130,7 +130,7 @@ spec:
           mountPath: /etc/quorum/qdata/tm/tessera-config-9.0.json.tmpl
           subPath: tessera-config-9.0.json.tmpl
       - name: quorum
-        image: quorumengineering/quorum:2.5.0
+        image: quorumengineering/quorum:20.10.0
         readinessProbe:
           exec:
             command:
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 
@@ -162,6 +161,7 @@ spec:
            RPC_APIS=admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum
            args=\" --gcmode archive --syncmode full --mine --minerthreads 1 \";
            RPC_APIS=\"$RPC_APIS,clique\";
+           args=\"$args --allow-insecure-unlock \";
            /usr/local/bin/geth \
            --datadir $QUORUM_DATA_DIR \
            $args \

--- a/7nodes/clique-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node2-quorum-deployment.yaml
+++ b/7nodes/clique-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node2-quorum-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       securityContext:
       initContainers:
       - name: quorum-genesis-init-container
-        image: quorumengineering/quorum:2.5.0
+        image: quorumengineering/quorum:20.10.0
         command: [ "sh" ]
         args:
         - "-cx"
@@ -58,7 +58,7 @@ spec:
           readOnly: false
       containers:
       - name: tessera
-        image: quorumengineering/tessera:0.10.4
+        image: quorumengineering/tessera:20.10.0
         command: ["sh"]
         args:
         - "-cx"
@@ -130,7 +130,7 @@ spec:
           mountPath: /etc/quorum/qdata/tm/tessera-config-9.0.json.tmpl
           subPath: tessera-config-9.0.json.tmpl
       - name: quorum
-        image: quorumengineering/quorum:2.5.0
+        image: quorumengineering/quorum:20.10.0
         readinessProbe:
           exec:
             command:
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 
@@ -162,6 +161,7 @@ spec:
            RPC_APIS=admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum
            args=\" --gcmode archive --syncmode full --mine --minerthreads 1 \";
            RPC_APIS=\"$RPC_APIS,clique\";
+           args=\"$args --allow-insecure-unlock \";
            /usr/local/bin/geth \
            --datadir $QUORUM_DATA_DIR \
            $args \

--- a/7nodes/clique-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node3-quorum-deployment.yaml
+++ b/7nodes/clique-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node3-quorum-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       securityContext:
       initContainers:
       - name: quorum-genesis-init-container
-        image: quorumengineering/quorum:2.5.0
+        image: quorumengineering/quorum:20.10.0
         command: [ "sh" ]
         args:
         - "-cx"
@@ -58,7 +58,7 @@ spec:
           readOnly: false
       containers:
       - name: tessera
-        image: quorumengineering/tessera:0.10.4
+        image: quorumengineering/tessera:20.10.0
         command: ["sh"]
         args:
         - "-cx"
@@ -130,7 +130,7 @@ spec:
           mountPath: /etc/quorum/qdata/tm/tessera-config-9.0.json.tmpl
           subPath: tessera-config-9.0.json.tmpl
       - name: quorum
-        image: quorumengineering/quorum:2.5.0
+        image: quorumengineering/quorum:20.10.0
         readinessProbe:
           exec:
             command:
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 
@@ -162,6 +161,7 @@ spec:
            RPC_APIS=admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum
            args=\" --gcmode archive --syncmode full --mine --minerthreads 1 \";
            RPC_APIS=\"$RPC_APIS,clique\";
+           args=\"$args --allow-insecure-unlock \";
            /usr/local/bin/geth \
            --datadir $QUORUM_DATA_DIR \
            $args \

--- a/7nodes/clique-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node4-quorum-deployment.yaml
+++ b/7nodes/clique-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node4-quorum-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       securityContext:
       initContainers:
       - name: quorum-genesis-init-container
-        image: quorumengineering/quorum:2.5.0
+        image: quorumengineering/quorum:20.10.0
         command: [ "sh" ]
         args:
         - "-cx"
@@ -58,7 +58,7 @@ spec:
           readOnly: false
       containers:
       - name: tessera
-        image: quorumengineering/tessera:0.10.4
+        image: quorumengineering/tessera:20.10.0
         command: ["sh"]
         args:
         - "-cx"
@@ -130,7 +130,7 @@ spec:
           mountPath: /etc/quorum/qdata/tm/tessera-config-9.0.json.tmpl
           subPath: tessera-config-9.0.json.tmpl
       - name: quorum
-        image: quorumengineering/quorum:2.5.0
+        image: quorumengineering/quorum:20.10.0
         readinessProbe:
           exec:
             command:
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 
@@ -162,6 +161,7 @@ spec:
            RPC_APIS=admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum
            args=\" --gcmode archive --syncmode full --mine --minerthreads 1 \";
            RPC_APIS=\"$RPC_APIS,clique\";
+           args=\"$args --allow-insecure-unlock \";
            /usr/local/bin/geth \
            --datadir $QUORUM_DATA_DIR \
            $args \

--- a/7nodes/clique-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node5-quorum-deployment.yaml
+++ b/7nodes/clique-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node5-quorum-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       securityContext:
       initContainers:
       - name: quorum-genesis-init-container
-        image: quorumengineering/quorum:2.5.0
+        image: quorumengineering/quorum:20.10.0
         command: [ "sh" ]
         args:
         - "-cx"
@@ -58,7 +58,7 @@ spec:
           readOnly: false
       containers:
       - name: tessera
-        image: quorumengineering/tessera:0.10.4
+        image: quorumengineering/tessera:20.10.0
         command: ["sh"]
         args:
         - "-cx"
@@ -130,7 +130,7 @@ spec:
           mountPath: /etc/quorum/qdata/tm/tessera-config-9.0.json.tmpl
           subPath: tessera-config-9.0.json.tmpl
       - name: quorum
-        image: quorumengineering/quorum:2.5.0
+        image: quorumengineering/quorum:20.10.0
         readinessProbe:
           exec:
             command:
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 
@@ -162,6 +161,7 @@ spec:
            RPC_APIS=admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum
            args=\" --gcmode archive --syncmode full --mine --minerthreads 1 \";
            RPC_APIS=\"$RPC_APIS,clique\";
+           args=\"$args --allow-insecure-unlock \";
            /usr/local/bin/geth \
            --datadir $QUORUM_DATA_DIR \
            $args \

--- a/7nodes/clique-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node6-quorum-deployment.yaml
+++ b/7nodes/clique-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node6-quorum-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       securityContext:
       initContainers:
       - name: quorum-genesis-init-container
-        image: quorumengineering/quorum:2.5.0
+        image: quorumengineering/quorum:20.10.0
         command: [ "sh" ]
         args:
         - "-cx"
@@ -58,7 +58,7 @@ spec:
           readOnly: false
       containers:
       - name: tessera
-        image: quorumengineering/tessera:0.10.4
+        image: quorumengineering/tessera:20.10.0
         command: ["sh"]
         args:
         - "-cx"
@@ -130,7 +130,7 @@ spec:
           mountPath: /etc/quorum/qdata/tm/tessera-config-9.0.json.tmpl
           subPath: tessera-config-9.0.json.tmpl
       - name: quorum
-        image: quorumengineering/quorum:2.5.0
+        image: quorumengineering/quorum:20.10.0
         readinessProbe:
           exec:
             command:
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 
@@ -162,6 +161,7 @@ spec:
            RPC_APIS=admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum
            args=\" --gcmode archive --syncmode full --mine --minerthreads 1 \";
            RPC_APIS=\"$RPC_APIS,clique\";
+           args=\"$args --allow-insecure-unlock \";
            /usr/local/bin/geth \
            --datadir $QUORUM_DATA_DIR \
            $args \

--- a/7nodes/clique-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node7-quorum-deployment.yaml
+++ b/7nodes/clique-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node7-quorum-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       securityContext:
       initContainers:
       - name: quorum-genesis-init-container
-        image: quorumengineering/quorum:2.5.0
+        image: quorumengineering/quorum:20.10.0
         command: [ "sh" ]
         args:
         - "-cx"
@@ -58,7 +58,7 @@ spec:
           readOnly: false
       containers:
       - name: tessera
-        image: quorumengineering/tessera:0.10.4
+        image: quorumengineering/tessera:20.10.0
         command: ["sh"]
         args:
         - "-cx"
@@ -130,7 +130,7 @@ spec:
           mountPath: /etc/quorum/qdata/tm/tessera-config-9.0.json.tmpl
           subPath: tessera-config-9.0.json.tmpl
       - name: quorum
-        image: quorumengineering/quorum:2.5.0
+        image: quorumengineering/quorum:20.10.0
         readinessProbe:
           exec:
             command:
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 
@@ -162,6 +161,7 @@ spec:
            RPC_APIS=admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum
            args=\" --gcmode archive --syncmode full --mine --minerthreads 1 \";
            RPC_APIS=\"$RPC_APIS,clique\";
+           args=\"$args --allow-insecure-unlock \";
            /usr/local/bin/geth \
            --datadir $QUORUM_DATA_DIR \
            $args \

--- a/7nodes/istanbul-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node1-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node1-quorum-deployment.yaml
@@ -112,7 +112,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;

--- a/7nodes/istanbul-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node2-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node2-quorum-deployment.yaml
@@ -112,7 +112,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;

--- a/7nodes/istanbul-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node3-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node3-quorum-deployment.yaml
@@ -112,7 +112,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;

--- a/7nodes/istanbul-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node4-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node4-quorum-deployment.yaml
@@ -112,7 +112,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;

--- a/7nodes/istanbul-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node5-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node5-quorum-deployment.yaml
@@ -112,7 +112,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;

--- a/7nodes/istanbul-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node6-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node6-quorum-deployment.yaml
@@ -112,7 +112,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;

--- a/7nodes/istanbul-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node7-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node7-quorum-deployment.yaml
@@ -112,7 +112,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;

--- a/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node1-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node1-quorum-deployment.yaml
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 

--- a/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node1-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node1-quorum-deployment.yaml
@@ -151,7 +151,6 @@ spec:
            cat /etc/quorum/genesis/genesis-geth.json;
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
-  
            until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 

--- a/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node2-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node2-quorum-deployment.yaml
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 

--- a/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node2-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node2-quorum-deployment.yaml
@@ -151,7 +151,6 @@ spec:
            cat /etc/quorum/genesis/genesis-geth.json;
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
-  
            until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 

--- a/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node3-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node3-quorum-deployment.yaml
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 

--- a/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node3-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node3-quorum-deployment.yaml
@@ -151,7 +151,6 @@ spec:
            cat /etc/quorum/genesis/genesis-geth.json;
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
-  
            until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 

--- a/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node4-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node4-quorum-deployment.yaml
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 

--- a/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node4-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node4-quorum-deployment.yaml
@@ -151,7 +151,6 @@ spec:
            cat /etc/quorum/genesis/genesis-geth.json;
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
-  
            until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 

--- a/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node5-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node5-quorum-deployment.yaml
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 

--- a/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node5-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node5-quorum-deployment.yaml
@@ -151,7 +151,6 @@ spec:
            cat /etc/quorum/genesis/genesis-geth.json;
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
-  
            until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 

--- a/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node6-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node6-quorum-deployment.yaml
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 

--- a/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node6-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node6-quorum-deployment.yaml
@@ -151,7 +151,6 @@ spec:
            cat /etc/quorum/genesis/genesis-geth.json;
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
-  
            until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 

--- a/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node7-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node7-quorum-deployment.yaml
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 

--- a/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node7-quorum-deployment.yaml
+++ b/7nodes/istanbul-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node7-quorum-deployment.yaml
@@ -151,7 +151,6 @@ spec:
            cat /etc/quorum/genesis/genesis-geth.json;
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
-  
            until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 

--- a/7nodes/raft-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node1-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node1-quorum-deployment.yaml
@@ -112,7 +112,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;

--- a/7nodes/raft-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node2-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node2-quorum-deployment.yaml
@@ -112,7 +112,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;

--- a/7nodes/raft-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node3-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node3-quorum-deployment.yaml
@@ -112,7 +112,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;

--- a/7nodes/raft-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node4-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node4-quorum-deployment.yaml
@@ -112,7 +112,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;

--- a/7nodes/raft-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node5-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node5-quorum-deployment.yaml
@@ -112,7 +112,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;

--- a/7nodes/raft-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node6-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node6-quorum-deployment.yaml
@@ -112,7 +112,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;

--- a/7nodes/raft-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node7-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-constellation/k8s-yaml-pvc/deployments/quorum-node7-quorum-deployment.yaml
@@ -112,7 +112,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;

--- a/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node1-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node1-quorum-deployment.yaml
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 

--- a/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node1-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node1-quorum-deployment.yaml
@@ -151,7 +151,6 @@ spec:
            cat /etc/quorum/genesis/genesis-geth.json;
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
-  
            until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 

--- a/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node2-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node2-quorum-deployment.yaml
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 

--- a/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node2-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node2-quorum-deployment.yaml
@@ -151,7 +151,6 @@ spec:
            cat /etc/quorum/genesis/genesis-geth.json;
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
-  
            until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 

--- a/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node3-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node3-quorum-deployment.yaml
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 

--- a/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node3-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node3-quorum-deployment.yaml
@@ -151,7 +151,6 @@ spec:
            cat /etc/quorum/genesis/genesis-geth.json;
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
-  
            until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 

--- a/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node4-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node4-quorum-deployment.yaml
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 

--- a/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node4-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node4-quorum-deployment.yaml
@@ -151,7 +151,6 @@ spec:
            cat /etc/quorum/genesis/genesis-geth.json;
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
-  
            until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 

--- a/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node5-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node5-quorum-deployment.yaml
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 

--- a/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node5-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node5-quorum-deployment.yaml
@@ -151,7 +151,6 @@ spec:
            cat /etc/quorum/genesis/genesis-geth.json;
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
-  
            until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 

--- a/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node6-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node6-quorum-deployment.yaml
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 

--- a/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node6-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node6-quorum-deployment.yaml
@@ -151,7 +151,6 @@ spec:
            cat /etc/quorum/genesis/genesis-geth.json;
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
-  
            until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 

--- a/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node7-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node7-quorum-deployment.yaml
@@ -142,7 +142,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -153,7 +152,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
   
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 
 

--- a/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node7-quorum-deployment.yaml
+++ b/7nodes/raft-7nodes-tessera/k8s-yaml-pvc/deployments/quorum-node7-quorum-deployment.yaml
@@ -151,7 +151,6 @@ spec:
            cat /etc/quorum/genesis/genesis-geth.json;
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
-  
            until $(wget --quiet --tries=1 --spider http://127.0.0.1:9001/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
            echo transaction manager is up;
 

--- a/templates/k8s/quorum-deployment.yaml.erb
+++ b/templates/k8s/quorum-deployment.yaml.erb
@@ -210,12 +210,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
  <%- if @Tm_Name == "tessera" -%>
-   <%- if @Security_Context != [] -%> <%# if a security context is set, assume we cannot install packages, e.g. curl, so sleep for 60 to give the TM time to startup. %>
-           echo sleeping for 60 seconds to wait for the transaction manager to startup.
-           sleep 60;
-   <%- else -%>  <%# if a security context not set, assume we can install packages, e.g. curl, we can do a check to see when the TM comes up. %>
            until $(wget --quiet --tries=1 --spider http://127.0.0.1:<%= @Tm_Port %>/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
-   <%- end -%>
            echo transaction manager is up;
  <%- else -%>
            sleep 5;

--- a/templates/k8s/quorum-deployment.yaml.erb
+++ b/templates/k8s/quorum-deployment.yaml.erb
@@ -200,7 +200,6 @@ spec:
         args:
         - "-cx"
         - "
-           apk add curl;
            apk add jq;
 
            ln -s $QUORUM_HOME/permission-nodes/permissioned-nodes.json $QUORUM_DATA_DIR/permissioned-nodes.json;
@@ -215,7 +214,7 @@ spec:
            echo sleeping for 60 seconds to wait for the transaction manager to startup.
            sleep 60;
    <%- else -%>  <%# if a security context not set, assume we can install packages, e.g. curl, we can do a check to see when the TM comes up. %>
-           until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:<%= @Tm_Port %>/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+           until $(wget --quiet --tries=1 --spider http://127.0.0.1:<%= @Tm_Port %>/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
    <%- end -%>
            echo transaction manager is up;
  <%- else -%>


### PR DESCRIPTION
Based on [this](https://stackoverflow.com/questions/47722898/how-to-do-a-docker-healthcheck-with-wget-instead-of-curl)

Reasons:

1. I believe package installation during container's startup is antipattern
2. I've had an issue couple of times when curl has failed to install during startup and quorum container has fallen into infinite loop due to missing curl command, but pod was still running as there are no liveness probe.
3. alpine has built-in wget and curl is used only for this check, can be easily replaced


P.S. Proper way would be also to implement liveness probe but I'm not that familiar with Quorum yet, so any suggestions are much appreciated.

P.S. I've noticed [quorum-kubernetes](https://github.com/ConsenSys/quorum-kubernetes) doesn't install/use jq, so maybe it can be removed as well? Out of curiosity, those two repos are maintained by different teams or why there  so much differences in manifests?
