### PR TITLE
Add basic documentation for local dev with qctl.

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -45,7 +45,7 @@ build the containers locally the script will set the docker env to the minikube 
 
 from the `qubernetes/dev` dir 
 ```
-$> cd qubernetes/dev
+$> cd qubernetes/dev/quorum
 ```
 
 run the build script
@@ -106,11 +106,11 @@ $> qctl geth exec quorum-node1 'eth.blockNumber'
 ```
 
 #### Look inside the generated minimal config `qubernetes.generate.yaml`
-The configuration we generate above (`qubernetes/dev/istanbul-loca/qubernetes.generate.yaml`) should have the 
+The configuration we generate above (`qubernetes/dev/istanbul-local/qubernetes.generate.yaml`) should have the 
 `Docker_Repo_Full` field set. 
 When `Docker_Repo_Full` is set, the `Quorum_Version` field is ignored and the local container (`quorum-local`) is used instead.
 
-**example** `qubernetes/dev/istanbul-loca/qubernetes.generate.yaml`:
+**example** `qubernetes/dev/istanbul-local/qubernetes.generate.yaml`:
 ```
 genesis:
   consensus: istanbul
@@ -161,7 +161,7 @@ nodes:
 We can modify the above `qubernetes.generate.yaml` to test a mixed net where `quorum-node1` runs 2.7.0 and 
 `quorum-node2` and `quorum-node3` run our local container, by removing `Docker_Repo_Full` from `- Node_UserIdent: quorum-node1`
 
-**example mixed net** `qubernetes/dev/istanbul-loca/qubernetes.generate.yaml`:
+**example mixed net** `qubernetes/dev/istanbul-local/qubernetes.generate.yaml`:
 ```
 genesis:
   consensus: istanbul
@@ -207,6 +207,12 @@ nodes:
 ```
 
 After modifying the configuration, the network will have to be generate and deployed again
+
+delete the previous network if it is still running
+```
+$> qctl destroy network
+```
+generate and deploy the mixed network
 ```
 $> qctl generate network --create
 $> qctl deploy network --wait

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,226 @@
+## Local Developing and Testing with `qctl` 
+
+**note:** this requires [minikube](https://minikube.sigs.k8s.io/docs/start/).
+
+Developing and testing local quorum code requires that we can build local docker containers which minikube can access.
+We will go through the steps to do this:
+
+1. [Make sure minikube is installed and start it up](#step1)
+1. [Setup your local quorum project for building local minikube containers](#step2)
+2. [Build your local image for minikube](#step3)
+3. [Run a Quorum network with `qctl` and a local container](#step4)
+4. [Run a Mixed Quorum Network (local container nodes, and versioned nodes)](#step5)
+
+#### <a name="step1"></a> 1. Make sure minikube is installed and start it up.
+install [minikube](https://minikube.sigs.k8s.io/docs/start/).  
+
+start minikube
+```
+$> minikube start --memory 6144 
+```
+
+#### <a name="step2"></a> 2. Setup your local quorum project for building local minikube containers
+
+from the quberentes dev directory
+```
+$> cd qubernetes/dev
+```
+clone the Quorum repo you wish to work with
+```
+$> git clone https://github.com/ConsenSys/quorum.git
+```
+copy over the helper scripts and Dockerfiles
+```
+$> cp docker-helpers/* quorum
+```
+checkout the branch you wish to work with
+```
+$> cd quorum
+$> git checkout $YOUR_BRANCH
+```
+
+#### <a name="step3"></a> 3. Build your local image for minikube
+
+build the containers locally the script will set the docker env to the minikube docker env, `eval $(minikube docker-env)`
+
+from the `qubernetes/dev` dir 
+```
+$> cd qubernetes/dev
+```
+
+run the build script
+```
+$> ./quorum-build-all.sh
+```
+
+check that the images have been build and are in the minikube docker env:
+```
+$> eval $(minikube docker-env)
+$> docker images
+REPOSITORY                                TAG           IMAGE ID       CREATED              SIZE
+quorum-local                              latest        01dbfb31dc13   About a minute ago   1.29GB
+quorum-base-local                         latest        882a062e4017   2 minutes ago        946MB
+...
+k8s.gcr.io/etcd                           3.4.3-0       303ce5db0e90   15 months ago        288MB
+k8s.gcr.io/pause                          3.1           da86e6ba6ca1   3 years ago          742kB
+gcr.io/k8s-minikube/storage-provisioner   v1.8.1        4689081edb10   3 years ago          80.8MB
+```
+
+#### <a name="step4"></a> 4. Run a Quorum network with `qctl` and a local container 
+
+Create a Quorum network using your local container image. 
+
+Use `qctl` with the `--qimagefull` flag set to the name of your local image, e.g. `--qimagefull=quorum-local`
+
+open a new tab or set the docker context back to your host
+```
+$> eval $(minikube docker-env --unset)
+```
+
+from your `qubernetes/dev` directory.
+```
+$> cd qubernetes/dev
+```
+
+create a subdirectory `istanbul-local` inside of `qubernetes/dev`
+```
+$> mkdir istanbul-local 
+```
+
+export the global env vars required for `qctl`
+```
+$> export QUBE_CONFIG=$(pwd)/istanbul-local/qubernetes.generate.yaml
+$> export QUBE_K8S_DIR=$(pwd)/istanbul-local/out
+```
+
+create a network with your local quorum image
+```
+$> qctl init --consensus=istanbul --qimagefull=quorum-local --num 3
+$> qctl generate network --create
+$> qctl deploy network --wait 
+```
+
+test the block number
+```
+$> qctl geth exec quorum-node1 'eth.blockNumber'
+```
+
+#### Look inside the generated minimal config `qubernetes.generate.yaml`
+The configuration we generate above (`qubernetes/dev/istanbul-loca/qubernetes.generate.yaml`) should have the 
+`Docker_Repo_Full` field set. 
+When `Docker_Repo_Full` is set, the `Quorum_Version` field is ignored and the local container (`quorum-local`) is used instead.
+
+**example** `qubernetes/dev/istanbul-loca/qubernetes.generate.yaml`:
+```
+genesis:
+  consensus: istanbul
+  Quorum_Version: 2.7.0
+  Tm_Version: 0.10.6
+  Chain_Id: "1000"
+nodes:
+- Node_UserIdent: quorum-node1
+  Key_Dir: key1
+  quorum:
+    quorum:
+      consensus: istanbul
+      Quorum_Version: 2.7.0
+      Docker_Repo_Full: quorum-local
+    tm:
+      Name: tessera
+      Tm_Version: 0.10.6
+  geth:
+    Geth_Startup_Params: ""
+- Node_UserIdent: quorum-node2
+  Key_Dir: key2
+  quorum:
+    quorum:
+      consensus: istanbul
+      Quorum_Version: 2.7.0
+      Docker_Repo_Full: quorum-local
+    tm:
+      Name: tessera
+      Tm_Version: 0.10.6
+  geth:
+    Geth_Startup_Params: ""
+- Node_UserIdent: quorum-node3
+  Key_Dir: key3
+  quorum:
+    quorum:
+      consensus: istanbul
+      Quorum_Version: 2.7.0
+      Docker_Repo_Full: quorum-local
+    tm:
+      Name: tessera
+      Tm_Version: 0.10.6
+  geth:
+    Geth_Startup_Params: ""
+```
+
+#### <a name="step5"></a> 5. Run a Mixed Quorum Network (local container nodes, and versioned nodes)
+
+We can modify the above `qubernetes.generate.yaml` to test a mixed net where `quorum-node1` runs 2.7.0 and 
+`quorum-node2` and `quorum-node3` run our local container, by removing `Docker_Repo_Full` from `- Node_UserIdent: quorum-node1`
+
+**example mixed net** `qubernetes/dev/istanbul-loca/qubernetes.generate.yaml`:
+```
+genesis:
+  consensus: istanbul
+  Quorum_Version: 2.7.0
+  Tm_Version: 0.10.6
+  Chain_Id: "1000"
+nodes:
+- Node_UserIdent: quorum-node1
+  Key_Dir: key1
+  quorum:
+    quorum:
+      consensus: istanbul
+      Quorum_Version: 2.7.0
+    tm:
+      Name: tessera
+      Tm_Version: 0.10.6
+  geth:
+    Geth_Startup_Params: ""
+- Node_UserIdent: quorum-node2
+  Key_Dir: key2
+  quorum:
+    quorum:
+      consensus: istanbul
+      Quorum_Version: 2.7.0
+      Docker_Repo_Full: quorum-local
+    tm:
+      Name: tessera
+      Tm_Version: 0.10.6
+  geth:
+    Geth_Startup_Params: ""
+- Node_UserIdent: quorum-node3
+  Key_Dir: key3
+  quorum:
+    quorum:
+      consensus: istanbul
+      Quorum_Version: 2.7.0
+      Docker_Repo_Full: quorum-local
+    tm:
+      Name: tessera
+      Tm_Version: 0.10.6
+  geth:
+    Geth_Startup_Params: ""
+```
+
+After modifying the configuration, the network will have to be generate and deployed again
+```
+$> qctl generate network --create
+$> qctl deploy network --wait
+```
+
+
+### Subsequent local builds
+Once you have the base quorum image build, e.g. `quorum-base-local` build when running `./quorum-build-all.sh` in step 2 
+for faster subsequent builds when you make changes to the Quorum code, use: `./build-quorum.sh`
+```
+> ./build-quorum.sh
+```
+
+### Building multiple local images
+`./build-quorum.sh MY_QUORUM_IMAGE` will build a docker image with the name set to the passed in param.
+This is useful when you wish to run multiple local docker images, e.g. adding logging,testing across different branches, 
+running a quorum network with multiple different quorum containers, etc. 

--- a/dev/docker-helpers/Dockerfile.quorum
+++ b/dev/docker-helpers/Dockerfile.quorum
@@ -1,0 +1,10 @@
+# docker build -t quorum-local -f Dockerfile.quorum .
+FROM quorum-base-local:latest
+
+ADD . /go-ethereum
+RUN cd /go-ethereum && make geth
+
+RUN cp /go-ethereum/build/bin/geth /usr/local/bin/
+RUN rm -r /go-ethereum
+EXPOSE 8545 8546 8547 30303 30303/udp
+ENTRYPOINT ["geth"]

--- a/dev/docker-helpers/Dockerfile.quorumbase
+++ b/dev/docker-helpers/Dockerfile.quorumbase
@@ -1,0 +1,10 @@
+# Build Geth in a stock Go builder container
+# docker build -t quorum-base-local -f Dockerfile.quorumbase .
+FROM golang:1.13-alpine
+
+RUN apk add --no-cache make gcc musl-dev linux-headers git ca-certificates
+
+#ADD /Users/libby/go/src/github.com/ethereum/go-ethereum /go-ethereum
+RUN echo "PWD is: $PWD"
+ADD $PWD /go-ethereum
+RUN cd /go-ethereum && make geth

--- a/dev/docker-helpers/quorum-build-all.sh
+++ b/dev/docker-helpers/quorum-build-all.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+function usage() {
+  echo " ./quorum-build-all.sh IMAGE_NAME"
+  echo "  example: ./quorum-build-all.sh "
+  echo "  example: ./quorum-build-all.sh quorum-test-ibft"
+}
+
+echo "$#"
+if [[ "$#" -gt 1 ]];
+then
+  usage
+  exit 1
+fi
+
+IMAGE_NAME=quorum-local
+
+if [[ "$#" -eq 1 ]];
+then
+  IMAGE_NAME=$1
+fi
+
+echo "building quorum image $IMAGE_NAME"
+
+eval $(minikube docker-env)
+docker build -t quorum-base-local -f Dockerfile.quorumbase . && docker build -t $IMAGE_NAME -f Dockerfile.quorum .

--- a/dev/docker-helpers/quorum-build.sh
+++ b/dev/docker-helpers/quorum-build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+function usage() {
+  echo " ./quorum-build.sh IMAGE_NAME"
+  echo "  example: ./quorum-build.sh "
+  echo "  example: ./quorum-build.sh quorum-test-ibft"
+}
+
+if [[ $# -gt 1 ]];
+then
+  usage
+fi
+
+IMAGE_NAME=quorum-local
+
+if [[ $# -eq 1 ]];
+then
+  IMAGE_NAME=$1
+fi
+
+eval $(minikube docker-env)
+echo "building quorum image $IMAGE_NAME"
+
+docker build -t $IMAGE_NAME -f Dockerfile.quorum .


### PR DESCRIPTION
* documentation for building local images that are accessible via
minikube.
* example of running a mixed net (local images, and release).