### PR TITLE
Updating default quorum version to 21.7.1 and tessera version to 21.7.2

### DIFF
--- a/7nodes/istanbul-7nodes-constellation/qubernetes-istanbul-constellation-7nodes-pvc.yaml
+++ b/7nodes/istanbul-7nodes-constellation/qubernetes-istanbul-constellation-7nodes-pvc.yaml
@@ -1,7 +1,7 @@
 genesis:
   # supported: (raft | istanbul)
   consensus: istanbul
-  Quorum_Version: 20.10.0
+  Quorum_Version: 21.7.1
   Tm_Version: 0.3.2
   Chain_Id: 10
 
@@ -33,7 +33,7 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: constellation
@@ -45,7 +45,7 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: constellation
@@ -57,7 +57,7 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: constellation
@@ -69,7 +69,7 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: constellation
@@ -81,7 +81,7 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: constellation
@@ -93,7 +93,7 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: constellation
@@ -105,7 +105,7 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: constellation

--- a/7nodes/istanbul-7nodes-tessera/qubernetes-istanbul-tessera-7nodes-pvc.yaml
+++ b/7nodes/istanbul-7nodes-tessera/qubernetes-istanbul-tessera-7nodes-pvc.yaml
@@ -1,8 +1,8 @@
 genesis:
   # supported: (raft | istanbul)
   consensus: istanbul
-  Quorum_Version: 20.10.0
-  Tm_Version: 20.10.0
+  Quorum_Version: 21.7.1
+  Tm_Version: 21.7.2
   Chain_Id: 10
 
 config:
@@ -33,11 +33,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node2
      Key_Dir: key2
@@ -45,11 +45,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node3
      Key_Dir: key3
@@ -57,11 +57,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node4
      Key_Dir: key4
@@ -69,11 +69,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node5
      Key_Dir: key5
@@ -81,11 +81,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node6
      Key_Dir: key6
@@ -93,11 +93,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node7
      Key_Dir: key7
@@ -105,9 +105,9 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 

--- a/7nodes/raft-7nodes-constellation/qubernetes-raft-constellation-7nodes-pvc.yaml
+++ b/7nodes/raft-7nodes-constellation/qubernetes-raft-constellation-7nodes-pvc.yaml
@@ -2,7 +2,7 @@
 genesis:
   # supported: (raft | istanbul)
   consensus: raft
-  Quorum_Version: 20.10.0
+  Quorum_Version: 21.7.1
   Tm_Version: 0.3.2
   Chain_Id: 10
 
@@ -34,7 +34,7 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: raft
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: constellation
@@ -46,7 +46,7 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: raft
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: constellation
@@ -58,7 +58,7 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: raft
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: constellation
@@ -70,7 +70,7 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: raft
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: constellation
@@ -82,7 +82,7 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: raft
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: constellation
@@ -94,7 +94,7 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: raft
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: constellation
@@ -106,7 +106,7 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: raft
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: constellation

--- a/7nodes/raft-7nodes-tessera/qubernetes-raft-tessera-7nodes-pvc.yaml
+++ b/7nodes/raft-7nodes-tessera/qubernetes-raft-tessera-7nodes-pvc.yaml
@@ -2,8 +2,8 @@
 genesis:
   # supported: (raft | istanbul)
   consensus: raft
-  Quorum_Version: 20.10.0
-  Tm_Version: 20.10.0
+  Quorum_Version: 21.7.1
+  Tm_Version: 21.7.2
   Chain_Id: 10
 
 config:
@@ -34,11 +34,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: raft
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node2
      Key_Dir: key2
@@ -46,11 +46,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: raft
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node3
      Key_Dir: key3
@@ -58,11 +58,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: raft
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node4
      Key_Dir: key4
@@ -70,11 +70,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: raft
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node5
      Key_Dir: key5
@@ -82,11 +82,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: raft
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node6
      Key_Dir: key6
@@ -94,11 +94,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: raft
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node7
      Key_Dir: key7
@@ -106,8 +106,8 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: raft
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2

--- a/README.md
+++ b/README.md
@@ -238,11 +238,11 @@ nodes:
       quorum:
         # supported: (raft | istanbul)
         consensus: istanbul
-        Quorum_Version: 2.6.0
+        Quorum_Version: 21.7.1
       tm:
         # (tessera|constellation)
         Name: tessera
-        Tm_Version: 0.10.4
+        Tm_Version: 21.7.2
 
   - Node_UserIdent: quorum-node2
     Key_Dir: key2
@@ -250,11 +250,11 @@ nodes:
       quorum:
         # supported: (raft | istanbul)
         consensus: istanbul
-        Quorum_Version: 2.6.0
+        Quorum_Version: 21.7.1
       tm:
         # (tessera|constellation)
         Name: tessera
-        Tm_Version: 0.10.4
+        Tm_Version: 21.7.2
 # add more nodes if you'd like
 #  - Node_UserIdent: quorum-node5
 #    Key_Dir: key5
@@ -262,11 +262,11 @@ nodes:
 #      quorum:
 #        # supported: (raft | istanbul)
 #        consensus: istanbul
-#        Quorum_Version: 2.6.0
+#        Quorum_Version: 21.7.1
 #      tm:
 #        # (tessera|constellation)
 #        Name: tessera
-#        Tm_Version: 0.10.4
+#        Tm_Version: 21.7.2
 ```
 
 * You can also run the `./quick-start-gen` command to generate the core config
@@ -275,14 +275,14 @@ $> ./quick-start-gen --help
 
 Usage: ./quick-start [options]
         --consensus[ACTION]          The consensus to use for the network (raft or istanbul), default istanbul
-    -q, --quorum-version[ACTION]     The version of quorum to deploy, default 2.6.0
-    -t, --tm-version[ACTION]         The version of the transaction manager to deploy, default 0.10.4
+    -q, --quorum-version[ACTION]     The version of quorum to deploy, default 21.7.1
+    -t, --tm-version[ACTION]         The version of the transaction manager to deploy, default 21.7.2
         --tm-name[ACTION]            The transaction manager (tessera|constellation) for the network, default tesera
     -c, --chain_id[ACTION]           The chain id for the network manager deploy, default 1000
     -n, --num-nodes[ACTION]          The number of nodes to deploy, default 4
     -h, --help                       prints this help
 
-$> ./quick-start-gen --chain-id=10 --consensus=raft --quorum-version=2.6.0 --tm-version=0.10.5 --tm-name=tessera --num-nodes=7
+$> ./quick-start-gen --chain-id=10 --consensus=raft --quorum-version=21.7.1 --tm-version=21.7.2 --tm-name=tessera --num-nodes=7
 ```
 
 2. Once you have your core config, e.g. qubernetes.yaml configured with your desired parameters: 

--- a/docs/adding-nodes.md
+++ b/docs/adding-nodes.md
@@ -19,11 +19,11 @@ nodes:
       quorum:
         # supported: (raft | istanbul)
         consensus: istanbul
-        Quorum_Version: 2.6.0
+        Quorum_Version: 21.7.1
       tm:
         # (tessera|constellation)
         Name: tessera
-        Tm_Version: 0.10.4
+        Tm_Version: 21.7.2
 ```
 
 2. Run `./qube-init --action=update qubernetes.yaml` (**note** the `action` flag has changed from `create` to `update`), 
@@ -37,4 +37,3 @@ nodes:
 To add nodes to a raft network, run the steps above with a config enabling raft, e.g. replace `qubernetes.yaml` with `qubernetes-raft.yaml`.
 
 3. If adding a raft node, run `helpers/add_nodes_to_k8s.sh raft`
- 

--- a/docs/cakeshop.md
+++ b/docs/cakeshop.md
@@ -11,11 +11,11 @@ quorum:
   quorum:
     # supported: (raft | istanbul)
     consensus: istanbul
-    Quorum_Version: 2.6.0
+    Quorum_Version: 21.7.1
   tm:
     # (tessera|constellation)
     Name: tessera
-    Tm_Version: 0.10.4
+    Tm_Version: 21.7.2
 cakeshop:
   version: 0.12.1
   service:

--- a/examples/config/clique.yaml
+++ b/examples/config/clique.yaml
@@ -17,8 +17,8 @@ k8s:
 genesis:
   # supported: (raft | istanbul)
   consensus: clique
-  Quorum_Version: 2.6.0
-  Tm_Version: 0.10.4
+  Quorum_Version: 21.7.1
+  Tm_Version: 21.7.2
   Chain_Id: 1000
 
 nodes:
@@ -29,11 +29,11 @@ nodes:
       quorum:
         # supported: (raft | istanbul)
         consensus: clique
-        Quorum_Version: 2.6.0
+        Quorum_Version: 21.7.1
       tm:
         # (tessera|constellation)
         Name: tessera
-        Tm_Version: 0.10.4
+        Tm_Version: 21.7.2
 
   - Node_UserIdent: quorum-node2
     Key_Dir: key2
@@ -41,11 +41,11 @@ nodes:
       quorum:
         # supported: (raft | istanbul)
         consensus: clique
-        Quorum_Version: 2.6.0
+        Quorum_Version: 21.7.1
       tm:
         # (tessera|constellation)
         Name: tessera
-        Tm_Version: 0.10.4
+        Tm_Version: 21.7.2
 
   - Node_UserIdent: quorum-node3
     Key_Dir: key3
@@ -53,11 +53,11 @@ nodes:
       quorum:
         # supported: (raft | istanbul)
         consensus: clique
-        Quorum_Version: 2.6.0
+        Quorum_Version: 21.7.1
       tm:
         # (tessera|constellation)
         Name: tessera
-        Tm_Version: 0.10.4
+        Tm_Version: 21.7.2
 
   - Node_UserIdent: quorum-node4
     Key_Dir: key4
@@ -65,8 +65,8 @@ nodes:
       quorum:
         # supported: (raft | istanbul)
         consensus: clique
-        Quorum_Version: 2.6.0
+        Quorum_Version: 21.7.1
       tm:
         # (tessera|constellation)
         Name: tessera
-        Tm_Version: 0.10.4
+        Tm_Version: 21.7.2

--- a/examples/config/custom-docker-repo.yaml
+++ b/examples/config/custom-docker-repo.yaml
@@ -16,8 +16,8 @@ k8s:
 genesis:
   # supported: (raft | istanbul)
   consensus: istanbul
-  Quorum_Version: 2.6.0
-  Tm_Version: 0.10.4
+  Quorum_Version: 21.7.1
+  Tm_Version: 21.7.2
   Chain_Id: 10
 
 # Add as many nodes as you wish below
@@ -30,12 +30,12 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
          Docker_Repo: MY_DOCKER_REPO
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
          Docker_Repo: MY_DOCKER_REPO
      geth:
        Geth_Startup_Params: --rpccorsdomain=\"*\"
@@ -46,13 +46,13 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
          # the docker repo that hold your quorum container
          Docker_Repo: MY_DOCKER_REPO
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
          # the docker repo that hold your quorum container
          Docker_Repo: MY_DOCKER_REPO
      geth:
@@ -64,11 +64,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
      geth:
        Geth_Startup_Params: --rpccorsdomain=\"*\"
 
@@ -78,8 +78,8 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2

--- a/examples/config/ingress-ws.yaml
+++ b/examples/config/ingress-ws.yaml
@@ -21,8 +21,8 @@ k8s:
 genesis:
   # supported: (raft | istanbul)
   consensus: istanbul
-  Quorum_Version: 2.6.0
-  Tm_Version: 0.10.4
+  Quorum_Version: 21.7.1
+  Tm_Version: 21.7.2
   Chain_Id: 10
 
 # Add as many nodes as you wish below
@@ -35,11 +35,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
      geth:
        Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\" --ws --wsorigins=\"*\" --wsaddr 0.0.0.0
 
@@ -49,11 +49,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
      geth:
        Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\" --ws --wsorigins=\"*\" --wsaddr 0.0.0.0
 
@@ -63,11 +63,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
      geth:
        Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\" --ws --wsorigins=\"*\" --wsaddr 0.0.0.0
 
@@ -77,8 +77,8 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2

--- a/examples/config/ingress.yaml
+++ b/examples/config/ingress.yaml
@@ -20,8 +20,8 @@ k8s:
 genesis:
   # supported: (raft | istanbul)
   consensus: istanbul
-  Quorum_Version: 2.6.0
-  Tm_Version: 0.10.4
+  Quorum_Version: 21.7.1
+  Tm_Version: 21.7.2
   Chain_Id: 10
 
 # Add as many nodes as you wish below
@@ -34,11 +34,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
      geth:
        Geth_Startup_Params: --rpccorsdomain=\"*\"
 
@@ -48,11 +48,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
      geth:
        Geth_Startup_Params: --rpccorsdomain=\"*\"
 
@@ -62,11 +62,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
      geth:
        Geth_Startup_Params: --rpccorsdomain=\"*\"
 
@@ -76,8 +76,8 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2

--- a/examples/config/network-policy.yaml
+++ b/examples/config/network-policy.yaml
@@ -13,8 +13,8 @@ k8s:
 genesis:
   # supported: (raft | istanbul)
   consensus: istanbul
-  Quorum_Version: 2.6.0
-  Tm_Version: 0.10.4
+  Quorum_Version: 21.7.1
+  Tm_Version: 21.7.2
   Chain_Id: 10
 
 # Add as many nodes as you wish below
@@ -27,11 +27,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node2
      Key_Dir: key2
@@ -39,11 +39,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node3
      Key_Dir: key3
@@ -51,11 +51,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node4
      Key_Dir: key4
@@ -63,8 +63,8 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2

--- a/examples/config/prometheus.yaml
+++ b/examples/config/prometheus.yaml
@@ -8,8 +8,8 @@ prometheus:
 genesis:
   # supported: (raft | istanbul)
   consensus: istanbul
-  Quorum_Version: 2.6.0
-  Tm_Version: 0.10.4
+  Quorum_Version: 21.7.1
+  Tm_Version: 21.7.2
   Chain_Id: 10
 
 # Add as many nodes as you wish below
@@ -22,11 +22,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
      geth:
        #Geth_Startup_Params: --rpccorsdomain=\"*\" --metrics --metrics.expensive --pprof --pprofaddr=0.0.0.0
        Geth_Startup_Params: --rpccorsdomain=\"*\"
@@ -37,11 +37,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
      geth:
        #Geth_Startup_Params: --rpccorsdomain=\"*\" --metrics --metrics.expensive --pprof --pprofaddr=0.0.0.0
        Geth_Startup_Params: --rpccorsdomain=\"*\"
@@ -52,11 +52,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
      geth:
        #Geth_Startup_Params: --rpccorsdomain=\"*\" --metrics --metrics.expensive --pprof --pprofaddr=0.0.0.0
        Geth_Startup_Params: --rpccorsdomain=\"*\"
@@ -67,8 +67,8 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2

--- a/examples/config/pvc-annotations.yaml
+++ b/examples/config/pvc-annotations.yaml
@@ -15,8 +15,8 @@ k8s:
 genesis:
   # supported: (raft | istanbul)
   consensus: istanbul
-  Quorum_Version: 2.6.0
-  Tm_Version: 0.10.4
+  Quorum_Version: 21.7.1
+  Tm_Version: 21.7.2
   Chain_Id: 10
 
 # Add as many nodes as you wish below
@@ -29,11 +29,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node2
      Key_Dir: key2
@@ -41,11 +41,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node3
      Key_Dir: key3
@@ -53,11 +53,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node4
      Key_Dir: key4
@@ -65,8 +65,8 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2

--- a/examples/config/pvc-set-storageclass.yaml
+++ b/examples/config/pvc-set-storageclass.yaml
@@ -14,8 +14,8 @@ k8s:
 genesis:
   # supported: (raft | istanbul)
   consensus: istanbul
-  Quorum_Version: 2.6.0
-  Tm_Version: 0.10.4
+  Quorum_Version: 21.7.1
+  Tm_Version: 21.7.2
   Chain_Id: 10
 
 # Add as many nodes as you wish below
@@ -28,11 +28,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node2
      Key_Dir: key2
@@ -40,11 +40,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node3
      Key_Dir: key3
@@ -52,11 +52,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node4
      Key_Dir: key4
@@ -64,8 +64,8 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2

--- a/examples/config/pvc-storageclass-1-per-node.yaml
+++ b/examples/config/pvc-storageclass-1-per-node.yaml
@@ -16,8 +16,8 @@ k8s:
 genesis:
   # supported: (raft | istanbul)
   consensus: istanbul
-  Quorum_Version: 2.6.0
-  Tm_Version: 0.10.4
+  Quorum_Version: 21.7.1
+  Tm_Version: 21.7.2
   Chain_Id: 10
 
 # Add as many nodes as you wish below
@@ -30,11 +30,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node2
      Key_Dir: key2
@@ -42,11 +42,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node3
      Key_Dir: key3
@@ -54,11 +54,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node4
      Key_Dir: key4
@@ -66,8 +66,8 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2

--- a/examples/config/qubes-full.yaml
+++ b/examples/config/qubes-full.yaml
@@ -37,8 +37,8 @@ prometheus:
 genesis:
   # supported: (raft | istanbul)
   consensus: istanbul
-  Quorum_Version: 2.6.0
-  Tm_Version: 0.10.4
+  Quorum_Version: 21.7.1
+  Tm_Version: 21.7.2
   Chain_Id: 10
 
 # Add as many nodes as you wish below
@@ -51,12 +51,12 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
          Docker_Repo: MY_DOCKER_REPO
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
          Docker_Repo: MY_DOCKER_REPO
      geth:
        network:
@@ -71,13 +71,13 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
          # the docker repo that hold your quorum container
          Docker_Repo: MY_DOCKER_REPO
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
          # the docker repo that hold your quorum container
          Docker_Repo: MY_DOCKER_REPO
      geth:
@@ -89,11 +89,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
      geth:
        Geth_Startup_Params: --rpccorsdomain=\"*\"
 
@@ -103,8 +103,8 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2

--- a/examples/config/security-context.yaml
+++ b/examples/config/security-context.yaml
@@ -23,8 +23,8 @@ k8s:
 genesis:
   # supported: (raft | istanbul)
   consensus: istanbul
-  Quorum_Version: 2.6.0
-  Tm_Version: 0.10.4
+  Quorum_Version: 21.7.1
+  Tm_Version: 21.7.2
   Chain_Id: 10
 
 # Add as many nodes as you wish below
@@ -37,11 +37,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node2
      Key_Dir: key2
@@ -49,11 +49,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node3
      Key_Dir: key3
@@ -61,11 +61,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node4
      Key_Dir: key4
@@ -73,8 +73,8 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2

--- a/examples/config/storageclass.yaml
+++ b/examples/config/storageclass.yaml
@@ -20,7 +20,7 @@ k8s:
 genesis:
   # supported: (raft | istanbul)
   consensus: istanbul
-  Quorum_Version: 2.6.0
+  Quorum_Version: 21.7.1
   Chain_Id: 10
 
 # Add as many nodes as you wish below
@@ -33,11 +33,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
      geth:
        Geth_Startup_Params: --rpccorsdomain=\"*\"
 
@@ -47,11 +47,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
      geth:
        Geth_Startup_Params: --rpccorsdomain=\"*\"
 
@@ -61,11 +61,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
      geth:
        Geth_Startup_Params: --rpccorsdomain=\"*\"
 
@@ -75,8 +75,8 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2

--- a/monitor/grafana/README.md
+++ b/monitor/grafana/README.md
@@ -17,8 +17,8 @@ prometheus:
 genesis:
   # supported: (raft | istanbul)
   consensus: istanbul
-  Quorum_Version: 2.6.0
-  Tm_Version: 0.10.4
+  Quorum_Version: 21.7.1
+  Tm_Version: 21.7.2
   Chain_Id: 10
 
 # Add as many nodes as you wish below
@@ -31,11 +31,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
      geth:
        #Geth_Startup_Params: --rpccorsdomain=\"*\" --metrics --metrics.expensive --pprof --pprofaddr=0.0.0.0
        Geth_Startup_Params: --rpccorsdomain=\"*\"
@@ -46,11 +46,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
      geth:
        #Geth_Startup_Params: --rpccorsdomain=\"*\" --metrics --metrics.expensive --pprof --pprofaddr=0.0.0.0
        Geth_Startup_Params: --rpccorsdomain=\"*\"
@@ -61,11 +61,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
      geth:
        #Geth_Startup_Params: --rpccorsdomain=\"*\" --metrics --metrics.expensive --pprof --pprofaddr=0.0.0.0
        Geth_Startup_Params: --rpccorsdomain=\"*\"
@@ -76,11 +76,11 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
 ```
 
 ## From Inside This Directory (qubernetes/monitor/grafana)

--- a/qctl/configcmd.go
+++ b/qctl/configcmd.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	// qctl generate config --qversion=2.6.0 --consensus=istanbul --tmversion=0.10.4 --tm=tessera --num=4
-	// qctl generate config --num=5 --qversion=2.7.0
+	// qctl generate config --qversion=21.7.1 --consensus=istanbul --tmversion=21.7.2 --tm=tessera --num=4
+	// qctl generate config --num=5 --qversion=21.7.1
 	initConfigCommand = cli.Command{
 		Name:  "init",
 		Usage: "creates a base qubernetes.yaml file which can be used to create a Quorum network.",

--- a/qctl/configyaml.go
+++ b/qctl/configyaml.go
@@ -14,8 +14,8 @@ var (
       # supported: (raft | istanbul)
       consensus: istanbul
       qibftBlock: 0
-      Quorum_Version: 2.6.0
-      Tm_Version: 0.10.4
+      Quorum_Version: 21.7.1
+      Tm_Version: 21.7.2
       Chain_Id: 1000
     nodes:
     `

--- a/qctl/scripts/addraftnode.sh
+++ b/qctl/scripts/addraftnode.sh
@@ -72,7 +72,7 @@ echo "Response from raft.addPeer: $RAFT_ADD_TO_CLUSTER_OUT"
 NEW_RAFT_ID=$(echo $RAFT_ADD_TO_CLUSTER_OUT | grep "[0-9]*" | sed 's/^"[0-9]*"//g' | sed 's/^.*pods//g' | sed 's/ //g' | sed $'s/[^[:print:]\t]//g' | sed 's/\[32m//g' | sed 's/\[0m//g' | sed 's/\[31m//g' | sed 's/"//g')
 echo "NEW_RAFT_ID: $NEW_RAFT_ID"
 
-if [[ "$QUORUM_IMAGE" == "2.7" ||  "$QUORUM_IMAGE" == "2.7.0" || "$QUORUM_IMAGE" == "2.6.0" ||
+if [[ "$QUORUM_IMAGE" == "21.7.1" || "$QUORUM_IMAGE" == "2.7" ||  "$QUORUM_IMAGE" == "2.7.0" || "$QUORUM_IMAGE" == "2.6.0" ||
       "$QUORUM_IMAGE" == "2.5.0" || "$QUORUM_IMAGE" == "2.4.0" || "$QUORUM_IMAGE" == "2.3.0" ]]; then
   echo qctl update node --gethparams '--raftjoinexisting $NEW_RAFT_ID' $NODE_NAME
   qctl update node --gethparams "--raftjoinexisting $NEW_RAFT_ID" $NODE_NAME

--- a/qctl/utils.go
+++ b/qctl/utils.go
@@ -16,9 +16,9 @@ var (
 	red   = color.New(color.FgRed)
 	green = color.New(color.FgGreen)
 
-	DefaultQuorumVersion        = "2.7.0"
+	DefaultQuorumVersion        = "21.7.1"
 	DefaultTmName               = "tessera"
-	DefaultTesseraVersion       = "0.10.6"
+	DefaultTesseraVersion       = "21.7.2"
 	DefaultConstellationVersion = "0.3.2"
 	DefaultConesensus           = "istanbul"
 	DefaultNodeNumber           = 4

--- a/qubernetes-raft.yaml
+++ b/qubernetes-raft.yaml
@@ -13,8 +13,8 @@ k8s:
 genesis:
   # supported: (raft | istanbul)
   consensus: raft
-  Quorum_Version: 2.6.0
-  Tm_Version: 0.11.0
+  Quorum_Version: 21.7.1
+  Tm_Version: 21.7.2
   Chain_Id: 1000
 
 # Add as many nodes as you wish below
@@ -27,12 +27,12 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: raft
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
          Docker_Repo:
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
          Docker_Repo:
        geth:
          network:
@@ -45,12 +45,12 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: raft
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
          Docker_Repo:
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
          Docker_Repo:
        geth:
          network:
@@ -63,12 +63,12 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: raft
-         Quorum_Version: 2.6.0
+         Quorum_Version: 21.7.1
          Docker_Repo:
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 0.10.4
+         Tm_Version: 21.7.2
          Docker_Repo:
        geth:
          network:
@@ -80,12 +80,12 @@ nodes:
 #       quorum:
 #         # supported: (raft | istanbul)
 #         consensus: raft
-#         Quorum_Version: 2.6.0
+#         Quorum_Version: 21.7.1
 #         Docker_Repo:
 #       tm:
 #         # (tessera|constellation)
 #         Name: tessera
-#         Tm_Version: 0.10.4
+#         Tm_Version: 21.7.2
 #         Docker_Repo:
 #       geth:
 #         network:
@@ -99,12 +99,12 @@ nodes:
 #       quorum:
 #         # supported: (raft | istanbul)
 #         consensus: raft
-#         Quorum_Version: 2.6.0
+#         Quorum_Version: 21.7.1
 #         Docker_Repo:
 #       tm:
 #         # (tessera|constellation)
 #         Name: tessera
-#         Tm_Version: 0.10.4
+#         Tm_Version: 21.7.2
 #         Docker_Repo:
 #       geth:
 #         network:
@@ -118,12 +118,12 @@ nodes:
 #       quorum:
 #         # supported: (raft | istanbul)
 #         consensus: raft
-#         Quorum_Version: 2.6.0
+#         Quorum_Version: 21.7.1
 #         Docker_Repo:
 #       tm:
 #         # (tessera|constellation)
 #         Name: tessera
-#         Tm_Version: 0.10.4
+#         Tm_Version: 21.7.2
 #         Docker_Repo:
 #       geth:
 #         network:
@@ -137,12 +137,12 @@ nodes:
 #      quorum:
 #        # supported: (raft | istanbul)
 #        consensus: raft
-#        Quorum_Version: 2.6.0
+#        Quorum_Version: 21.7.1
 #        Docker_Repo:
 #      tm:
 #        # (tessera|constellation)
 #        Name: tessera
-#        Tm_Version: 0.10.4
+#        Tm_Version: 21.7.2
 #        Docker_Repo:
 #      geth:
 #        network:

--- a/qubernetes.yaml
+++ b/qubernetes.yaml
@@ -1,5 +1,5 @@
 # see: ./quick-start-gen --help, if you wish to generate this file.
-# ./quick-start-gen --chain-id=1000  --tm-name=tessera --num-nodes=4  --consensus=istanbul --quorum-version=2.6.0  --tm-version=0.10.4
+# ./quick-start-gen --chain-id=1000  --tm-name=tessera --num-nodes=4  --consensus=istanbul --quorum-version=21.7.1  --tm-version=21.7.2
 # This is the core configuration file, at a minimum include:
 #   1. the number of nodes entries
 #   2. quorum's consensus (istanbul IBFT, or Raft)
@@ -20,8 +20,8 @@ k8s:
 genesis:
   # supported: (raft | istanbul)
   consensus: istanbul
-  Quorum_Version: 2.6.0
-  Tm_Version: 0.10.4
+  Quorum_Version: 21.7.1
+  Tm_Version: 21.7.2
   Chain_Id: 1000
 
 nodes:
@@ -32,11 +32,11 @@ nodes:
       quorum:
         # supported: (raft | istanbul)
         consensus: istanbul
-        Quorum_Version: 2.6.0
+        Quorum_Version: 21.7.1
       tm:
         # (tessera|constellation)
         Name: tessera
-        Tm_Version: 0.10.4
+        Tm_Version: 21.7.2
 
   - Node_UserIdent: quorum-node2
     Key_Dir: key2
@@ -44,11 +44,11 @@ nodes:
       quorum:
         # supported: (raft | istanbul)
         consensus: istanbul
-        Quorum_Version: 2.6.0
+        Quorum_Version: 21.7.1
       tm:
         # (tessera|constellation)
         Name: tessera
-        Tm_Version: 0.10.4
+        Tm_Version: 21.7.2
 
   - Node_UserIdent: quorum-node3
     Key_Dir: key3
@@ -56,11 +56,11 @@ nodes:
       quorum:
         # supported: (raft | istanbul)
         consensus: istanbul
-        Quorum_Version: 2.6.0
+        Quorum_Version: 21.7.1
       tm:
         # (tessera|constellation)
         Name: tessera
-        Tm_Version: 0.10.4
+        Tm_Version: 21.7.2
 
   - Node_UserIdent: quorum-node4
     Key_Dir: key4
@@ -68,11 +68,11 @@ nodes:
       quorum:
         # supported: (raft | istanbul)
         consensus: istanbul
-        Quorum_Version: 2.6.0
+        Quorum_Version: 21.7.1
       tm:
         # (tessera|constellation)
         Name: tessera
-        Tm_Version: 0.10.4
+        Tm_Version: 21.7.2
 # #add more nodes if you'd like
 #  - Node_UserIdent: quorum-node5
 #    Key_Dir: key5
@@ -80,11 +80,11 @@ nodes:
 #      quorum:
 #        # supported: (raft | istanbul)
 #        consensus: istanbul
-#        Quorum_Version: 2.6.0
+#        Quorum_Version: 21.7.1
 #      tm:
 #        # (tessera|constellation)
 #        Name: tessera
-#        Tm_Version: 0.10.4
+#        Tm_Version: 21.7.2
 #  #add more nodes if you'd like
 #  - Node_UserIdent: quorum-node6
 #    Key_Dir: key6
@@ -92,8 +92,8 @@ nodes:
 #      quorum:
 #        # supported: (raft | istanbul)
 #        consensus: istanbul
-#        Quorum_Version: 2.6.0
+#        Quorum_Version: 21.7.1
 #      tm:
 #        # (tessera|constellation)
 #        Name: tessera
-#        Tm_Version: 0.10.4
+#        Tm_Version: 21.7.2

--- a/quick-start-gen
+++ b/quick-start-gen
@@ -8,7 +8,7 @@ require 'optparse'
 @quick_start_out_yaml = "quick-start.yaml"
 
 # set up flag options :docker_repo :geth_verbosity :geth_startup_params
-options = {consensus: 'istanbul', quorum_version: '2.6.0', tm_version: '0.10.4', tm_name: 'tessera',
+options = {consensus: 'istanbul', quorum_version: '21.7.1', tm_version: '21.7.2', tm_name: 'tessera',
            chain_id: '1000', num_nodes: 4, docker_repo: '', geth_verbosity: 9, geth_startup_params: '' }
 
 OptionParser.new do |opts|
@@ -20,12 +20,12 @@ OptionParser.new do |opts|
   end
 
   opts.on("-q", "--quorum-version[ACTION]", String,
-          "The version of quorum to deploy, default 2.6.0") do |q|
+          "The version of quorum to deploy, default 21.7.1") do |q|
     options[:quorum_version] = q
   end
 
   opts.on("-t", "--tm-version[ACTION]", String,
-          "The version of the transaction manager to deploy, default 0.10.4") do |tm|
+          "The version of the transaction manager to deploy, default 21.7.2") do |tm|
     options[:tm_version] = tm
   end
 
@@ -60,7 +60,7 @@ OptionParser.new do |opts|
   end
   opts.on("-h", "--help", "prints this help.") do
     puts
-    puts "example: ./quick-start-gen --chain-id=1000 --consensus=istanbul --quorum-version=2.6.0 --tm-version=0.10.4 --tm-name=tessera --num-nodes=4 --geth-statrup-params=--rpccorsdomain=\"*\" --docker-repo=MY-REPO --geth-verobsity=3"
+    puts "example: ./quick-start-gen --chain-id=1000 --consensus=istanbul --quorum-version=21.7.1 --tm-version=21.7.2 --tm-name=tessera --num-nodes=4 --geth-statrup-params=--rpccorsdomain=\"*\" --docker-repo=MY-REPO --geth-verobsity=3"
     puts
     puts opts
     exit

--- a/templates/k8s/quorum-deployment.yaml.erb
+++ b/templates/k8s/quorum-deployment.yaml.erb
@@ -116,8 +116,12 @@ spec:
            echo DDIR is $DDIR;
            printenv;
 
+          <%- if @Tm_Version >= "21.7.0" -%>
+           TESSERA_VERSION=$$(/tessera/bin/tessera version);
+          <%- else -%>
            TESSERA_VERSION=$(unzip -p /tessera/tessera-app.jar META-INF/MANIFEST.MF | grep Tessera-Version | cut -d\" \" -f2);
            echo \"Tessera version (extracted from manifest file): ${TESSERA_VERSION}\";
+          <%- end -%>
 
            TESSERA_VERSION=\"${TESSERA_VERSION}-suffix\";
            Tess_Ver_First=$(echo ${TESSERA_VERSION} | awk -F. '{print $1}');
@@ -143,7 +147,12 @@ spec:
            if [ \"${Tess_Ver_First}\" -ge \"1\" ] || [ \"${Tess_Ver_Second}\" -ge \"9\" ]; then CONFIG_FINAL=${CONFIG_FINAL_9_0}; fi;
            echo $CONFIG_FINAL >  ${DDIR}/tessera-config-with-hosts.json;
            cat  ${DDIR}/tessera-config-with-hosts.json;
+
+           <%- if @Tm_Version >= "21.7.0" -%>
+           /tessera/bin/tessera -configfile $${DDIR}/tessera-config-with-hosts.json | tee -a ${QHOME}/logs/tessera.log;
+          <%- else -%>
            java -Xms128M -Xmx128M -jar /tessera/tessera-app.jar -configfile ${DDIR}/tessera-config-with-hosts.json | tee -a ${QHOME}/logs/tessera.log;
+          <%- end -%>
         "
      <%- end -%>
         ports:

--- a/testing/7nodes-config/qubernetes-clique-tessera-7nodes.yaml
+++ b/testing/7nodes-config/qubernetes-clique-tessera-7nodes.yaml
@@ -1,7 +1,7 @@
 genesis:
   consensus: clique
-  Quorum_Version: 20.10.0
-  Tm_Version: 20.10.0
+  Quorum_Version: 21.7.1
+  Tm_Version: 21.7.2
   Chain_Id: 10
 
 config:
@@ -31,69 +31,69 @@ nodes:
      quorum:
        quorum:
          consensus: clique
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node2
      Key_Dir: key2
      quorum:
        quorum:
          consensus: clique
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node3
      Key_Dir: key3
      quorum:
        quorum:
          consensus: clique
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node4
      Key_Dir: key4
      quorum:
        quorum:
          consensus: clique
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node5
      Key_Dir: key5
      quorum:
        quorum:
          consensus: clique
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node6
      Key_Dir: key6
      quorum:
        quorum:
          consensus: clique
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 
   -  Node_UserIdent: quorum-node7
      Key_Dir: key7
      quorum:
        quorum:
          consensus: clique
-         Quorum_Version: 20.10.0
+         Quorum_Version: 21.7.1
        tm:
          Name: tessera
-         Tm_Version: 20.10.0
+         Tm_Version: 21.7.2
 

--- a/testing/qversions-config/qubes-ibft-21.7.1-tessera-10.6.yaml
+++ b/testing/qversions-config/qubes-ibft-21.7.1-tessera-10.6.yaml
@@ -1,19 +1,13 @@
-cakeshop:
-  version: 0.12.1
-  service:
-    type: NodePort
-    nodePort: 30108
-
-# quorum and node specific config
+# ./quick-start-gen --chain-id=1000   --tm-name=tessera --num-nodes=3 --geth-statrup-params=--rpccorsdomain="*" --consensus=istanbul --quorum-version=21.7.1  --tm-version=0.10.2
 genesis:
   # supported: (raft | istanbul)
   consensus: istanbul
   Quorum_Version: 21.7.1
-  Tm_Version: 21.7.2
-  Chain_Id: 10
+  Tm_Version: 0.10.6
+  Chain_Id: 1000
 
 # Add as many nodes as you wish below
-# keys and config will be generated locally
+# Note:  keys should be set locally.
 nodes:
 
   -  Node_UserIdent: quorum-node1
@@ -26,7 +20,12 @@ nodes:
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 21.7.2
+         Tm_Version: 0.10.6
+       geth:
+         network:
+           id: 1000
+         verbosity: 9
+         Geth_Startup_Params: --rpccorsdomain=*
 
   -  Node_UserIdent: quorum-node2
      Key_Dir: key2
@@ -34,11 +33,16 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 21.7.1
+         Quorum_Version: 21.7.1 
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 21.7.2
+         Tm_Version: 0.10.6
+       geth:
+         network:
+           id: 1000
+         verbosity: 9
+         Geth_Startup_Params: --rpccorsdomain=*
 
   -  Node_UserIdent: quorum-node3
      Key_Dir: key3
@@ -46,20 +50,14 @@ nodes:
        quorum:
          # supported: (raft | istanbul)
          consensus: istanbul
-         Quorum_Version: 21.7.1
+         Quorum_Version: 21.7.1 
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 21.7.2
+         Tm_Version: 0.10.6
+       geth:
+         network:
+           id: 1000
+         verbosity: 9
+         Geth_Startup_Params: --rpccorsdomain=*
 
-  -  Node_UserIdent: quorum-node4
-     Key_Dir: key4
-     quorum:
-       quorum:
-         # supported: (raft | istanbul)
-         consensus: istanbul
-         Quorum_Version: 21.7.1
-       tm:
-         # (tessera|constellation)
-         Name: tessera
-         Tm_Version: 21.7.2

--- a/testing/qversions-config/qubes-ibft-21.7.1-tessera-21.7.2.yaml
+++ b/testing/qversions-config/qubes-ibft-21.7.1-tessera-21.7.2.yaml
@@ -1,18 +1,13 @@
-# This is the simplest configuration file, only specifying:
-#   1. the number of nodes
-#   2. quorum's consensus (istanbul IBFT, or Raft)
-#   3. the version of the quorum container and the transaction manager container.
-# Reasonable defaults will be chosen for the rest of the values, ports, associated K8s resources, etc.
-# quorum and node specific config
+# ./quick-start-gen --chain-id=1000   --tm-name=tessera --num-nodes=3 --geth-statrup-params=--rpccorsdomain="*" --consensus=istanbul --quorum-version=21.7.1  --tm-version=21.7.2
 genesis:
   # supported: (raft | istanbul)
   consensus: istanbul
   Quorum_Version: 21.7.1
   Tm_Version: 21.7.2
-  Chain_Id: 10
+  Chain_Id: 1000
 
 # Add as many nodes as you wish below
-# keys and config will be generated locally
+# Note:  keys should be set locally.
 nodes:
 
   -  Node_UserIdent: quorum-node1
@@ -26,6 +21,11 @@ nodes:
          # (tessera|constellation)
          Name: tessera
          Tm_Version: 21.7.2
+       geth:
+         network:
+           id: 1000
+         verbosity: 9
+         Geth_Startup_Params: --rpccorsdomain=*
 
   -  Node_UserIdent: quorum-node2
      Key_Dir: key2
@@ -38,6 +38,12 @@ nodes:
          # (tessera|constellation)
          Name: tessera
          Tm_Version: 21.7.2
+         Docker_Repo:
+       geth:
+         network:
+           id: 1000
+         verbosity: 9
+         Geth_Startup_Params: --rpccorsdomain=*
 
   -  Node_UserIdent: quorum-node3
      Key_Dir: key3
@@ -50,15 +56,9 @@ nodes:
          # (tessera|constellation)
          Name: tessera
          Tm_Version: 21.7.2
+       geth:
+         network:
+           id: 1000
+         verbosity: 9
+         Geth_Startup_Params: --rpccorsdomain=*
 
-  -  Node_UserIdent: quorum-node4
-     Key_Dir: key4
-     quorum:
-       quorum:
-         # supported: (raft | istanbul)
-         consensus: istanbul
-         Quorum_Version: 21.7.1
-       tm:
-         # (tessera|constellation)
-         Name: tessera
-         Tm_Version: 21.7.2

--- a/testing/qversions-config/qubes-raft-21.7.1-tessera-10.6.yaml
+++ b/testing/qversions-config/qubes-raft-21.7.1-tessera-10.6.yaml
@@ -1,13 +1,9 @@
-k8s:
-  service:
-    # NodePort | ClusterIP
-    type: ClusterIP
-
+# ./quick-start-gen --chain-id=1000   --tm-name=tessera --num-nodes=3 --geth-statrup-params=--rpccorsdomain="*" --consensus=raft --quorum-version=21.7.1  --tm-version=0.10.2
 genesis:
   # supported: (raft | istanbul)
   consensus: raft
   Quorum_Version: 21.7.1
-  Tm_Version: 21.7.2
+  Tm_Version: 0.10.4
   Chain_Id: 1000
 
 # Add as many nodes as you wish below
@@ -21,10 +17,18 @@ nodes:
          # supported: (raft | istanbul)
          consensus: raft
          Quorum_Version: 21.7.1
+         Tm_Version: 0.10.4
+         Docker_Repo:
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 21.7.2
+         Tm_Version: 0.10.6
+         Docker_Repo:
+       geth:
+         network:
+           id: 1000
+         verbosity: 9
+         Geth_Startup_Params: --rpccorsdomain=*
 
   -  Node_UserIdent: quorum-node2
      Key_Dir: key2
@@ -33,10 +37,17 @@ nodes:
          # supported: (raft | istanbul)
          consensus: raft
          Quorum_Version: 21.7.1
+         Docker_Repo:
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 21.7.2
+         Tm_Version: 0.10.6
+         Docker_Repo:
+       geth:
+         network:
+           id: 1000
+         verbosity: 9
+         Geth_Startup_Params: --rpccorsdomain=*
 
   -  Node_UserIdent: quorum-node3
      Key_Dir: key3
@@ -45,7 +56,15 @@ nodes:
          # supported: (raft | istanbul)
          consensus: raft
          Quorum_Version: 21.7.1
+         Docker_Repo:
        tm:
          # (tessera|constellation)
          Name: tessera
-         Tm_Version: 21.7.2
+         Tm_Version: 0.10.6
+         Docker_Repo:
+       geth:
+         network:
+           id: 1000
+         verbosity: 9
+         Geth_Startup_Params: --rpccorsdomain=*
+

--- a/testing/qversions-config/qubes-raft-21.7.1-tessera-21.7.2.yaml
+++ b/testing/qversions-config/qubes-raft-21.7.1-tessera-21.7.2.yaml
@@ -1,18 +1,13 @@
-# This is the simplest configuration file, only specifying:
-#   1. the number of nodes
-#   2. quorum's consensus (istanbul IBFT, or Raft)
-#   3. the version of the quorum container and the transaction manager container.
-# Reasonable defaults will be chosen for the rest of the values, ports, associated K8s resources, etc.
-# quorum and node specific config
+# ./quick-start-gen --chain-id=1000   --tm-name=tessera --num-nodes=3 --geth-statrup-params=--rpccorsdomain="*" --consensus=raft --quorum-version=21.7.1  --tm-version=21.7.2
 genesis:
   # supported: (raft | istanbul)
-  consensus: istanbul
+  consensus: raft
   Quorum_Version: 21.7.1
   Tm_Version: 21.7.2
-  Chain_Id: 10
+  Chain_Id: 1000
 
 # Add as many nodes as you wish below
-# keys and config will be generated locally
+# Note:  keys should be set locally.
 nodes:
 
   -  Node_UserIdent: quorum-node1
@@ -20,45 +15,49 @@ nodes:
      quorum:
        quorum:
          # supported: (raft | istanbul)
-         consensus: istanbul
+         consensus: raft
          Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
          Tm_Version: 21.7.2
+       geth:
+         network:
+           id: 1000
+         verbosity: 9
+         Geth_Startup_Params: --rpccorsdomain=*
 
   -  Node_UserIdent: quorum-node2
      Key_Dir: key2
      quorum:
        quorum:
          # supported: (raft | istanbul)
-         consensus: istanbul
+         consensus: raft
          Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
          Tm_Version: 21.7.2
+       geth:
+         network:
+           id: 1000
+         verbosity: 9
+         Geth_Startup_Params: --rpccorsdomain=*
 
   -  Node_UserIdent: quorum-node3
      Key_Dir: key3
      quorum:
        quorum:
          # supported: (raft | istanbul)
-         consensus: istanbul
+         consensus: raft
          Quorum_Version: 21.7.1
        tm:
          # (tessera|constellation)
          Name: tessera
          Tm_Version: 21.7.2
+       geth:
+         network:
+           id: 1000
+         verbosity: 9
+         Geth_Startup_Params: --rpccorsdomain=*
 
-  -  Node_UserIdent: quorum-node4
-     Key_Dir: key4
-     quorum:
-       quorum:
-         # supported: (raft | istanbul)
-         consensus: istanbul
-         Quorum_Version: 21.7.1
-       tm:
-         # (tessera|constellation)
-         Name: tessera
-         Tm_Version: 21.7.2


### PR DESCRIPTION
Updating default `quorum` version to `21.7.1` and `tessera` version to `21.7.2`. Also, updated example configs and documentation to reflect the same.

Added tests for the new default versions.