### PR TITLE
Updating qbft fork block to testQBFTBlock and added test for qbft

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,19 @@ RUN apt-get update
 
 # set tzdata non-interactive https://serverfault.com/questions/949991/how-to-install-tzdata-on-a-ubuntu-docker-image
 # for now need musl-dev for geneating account key from the private key
-RUN DEBIAN_FRONTEND="noninteractive" TZ="America/New_York" apt-get install -y ruby-full golang-go git make musl-dev xxd
+RUN DEBIAN_FRONTEND="noninteractive" TZ="America/New_York" apt-get install -y ruby-full golang-go git make musl-dev xxd wget
 RUN gem install colorize
 
-RUN go get github.com/getamis/istanbul-tools/cmd/istanbul
+RUN mkdir -p /root/go/bin
+
 ENV PATH=/root/go/bin:$PATH
 
-RUN go get github.com/getamis/istanbul-tools/cmd/istanbul && git clone https://github.com/ethereum/go-ethereum.git /root/go/src/github.com/ethereum/go-ethereum && \
+RUN cd /root/go/bin && \
+    wget https://artifacts.consensys.net/public/quorum-tools/raw/versions/v1.1.0/istanbul-tools_v1.1.0_linux_amd64.tar.gz &&  \
+    tar -xvf istanbul-tools_v1.1.0_linux_amd64.tar.gz &&  \
+    rm istanbul-tools_v1.1.0_linux_amd64.tar.gz
+
+RUN git clone https://github.com/ethereum/go-ethereum.git /root/go/src/github.com/ethereum/go-ethereum && \
     cd /root/go/src/github.com/ethereum/go-ethereum && git checkout e9ba536d && make all && \
     cp /root/go/src/github.com/ethereum/go-ethereum/build/bin/ethkey /root/go/bin/ && \
     cp /root/go/src/github.com/ethereum/go-ethereum/build/bin/bootnode /root/go/bin/ && \

--- a/qctl/configcmd.go
+++ b/qctl/configcmd.go
@@ -29,12 +29,12 @@ var (
 			},
 			&cli.StringFlag{
 				Name:  "consensus",
-				Usage: "Consensus to use raft | istanbul | clique.",
-				Value: DefaultConesensus,
+				Usage: "Consensus to use raft | istanbul | clique | qbft.",
+				Value: DefaultConsensus,
 			},
 			&cli.StringFlag{
-				Name:  "qibftblock",
-				Usage: "Blocknumber at which the network will switch over from ibft to qibft.",
+				Name:  "testqbftblock",
+				Usage: "Blocknumber at which the network will switch over from ibft to qbft.",
 				Value: "0",
 			},
 			&cli.StringFlag{
@@ -110,7 +110,7 @@ var (
 			tmVersion := c.String("tmversion")
 			transactionManager := c.String("tm")
 			consensus := c.String("consensus")
-			qibftblock := c.String("qibftblock")
+			testqbftblock := c.String("testqbftblock")
 			chainId := c.String("chainid")
 			qimagefull := c.String("qimagefull")
 			tmImageFull := c.String("tmimagefull")
@@ -159,8 +159,8 @@ var (
 			configYaml.Genesis.QuorumVersion = quorumVersion
 			configYaml.Genesis.TmVersion = tmVersion
 			configYaml.Genesis.Consensus = consensus
-			if consensus == "qibft" { // if --qibftblock=BLOCK_NUM not specified set to default block 0, else the user can specify --qibftblock=BLOCK_NUM
-				configYaml.Genesis.QibftBlock = qibftblock
+			if consensus == "qbft" { // if --testqbftblock=BLOCK_NUM not specified set to default block 0, else the user can specify --testqbftblock=BLOCK_NUM
+				configYaml.Genesis.TestQBFTBlock = testqbftblock
 			}
 			configYaml.Genesis.Chain_Id = chainId
 

--- a/qctl/configyaml.go
+++ b/qctl/configyaml.go
@@ -11,9 +11,9 @@ import (
 var (
 	qubeTemplateYaml = `
     genesis:
-      # supported: (raft | istanbul)
+      # supported: (raft | istanbul | qbft)
       consensus: istanbul
-      qibftBlock: 0
+      Test_QBFT_Block: 0
       Quorum_Version: 21.7.1
       Tm_Version: 21.7.2
       Chain_Id: 1000
@@ -91,7 +91,7 @@ type K8s struct {
 type QConfig struct {
 	Genesis struct {
 		Consensus     string `yaml:"consensus"`
-		QibftBlock    string `yaml:"qibftBlock,omitempty"`
+		TestQBFTBlock string `yaml:"Test_QBFT_Block,omitempty"`
 		QuorumVersion string `yaml:"Quorum_Version"`
 		TmVersion     string `yaml:"Tm_Version"`
 		Chain_Id      string `yaml:"Chain_Id"`

--- a/qctl/utils.go
+++ b/qctl/utils.go
@@ -20,7 +20,7 @@ var (
 	DefaultTmName               = "tessera"
 	DefaultTesseraVersion       = "21.7.2"
 	DefaultConstellationVersion = "0.3.2"
-	DefaultConesensus           = "istanbul"
+	DefaultConsensus            = "istanbul"
 	DefaultNodeNumber           = 4
 	DefaultChainId              = "1000"
 

--- a/quorum-config
+++ b/quorum-config
@@ -128,7 +128,7 @@ end
 
 # if the consensus is an ibft variant, set up the istanbul-validator-config.toml
 # this is used by the genesis template to initial extra data with necessary validator data.
-if @Genesis_Consensus == "istanbul" ||  @Genesis_Consensus  == "qibft"
+if @Genesis_Consensus == "istanbul" ||  @Genesis_Consensus  == "qbft"
   @Istanbul_Validator_Config = @Key_Dir_Base + "/istanbul-validator-config.toml"
   puts(@Istanbul_Validator_Config)
   File.open(@Istanbul_Validator_Config , "w") do |f|

--- a/templates/config/qubernetes-quickstart.yaml.erb
+++ b/templates/config/qubernetes-quickstart.yaml.erb
@@ -16,6 +16,10 @@ genesis:
   Quorum_Version: <%= @Quorum_Version %>
   Tm_Version: <%= @Tm_Version %>
   Chain_Id: <%= @Chain_Id %>
+  <%- if @consensus == "qbft" -%>
+  Test_QBFT_Block: 0
+  <%- end -%>
+
 
 # Add as many nodes as you wish below
 # Note:  keys should be set locally.

--- a/templates/k8s/quorum-deployment.yaml.erb
+++ b/templates/k8s/quorum-deployment.yaml.erb
@@ -234,7 +234,7 @@ spec:
            <%-# --raftdnsenable is need for adding additional nodes with hostnames. Without this node the network will start up fine, but adding nodes with enode host name URL will fail. -%>
            args=\" --gcmode archive --raft  --raftport <%= @Raft_Port %> --raftdnsenable \";
            RPC_APIS=\"$RPC_APIS,raft\";
-         <%- elsif @Consensus == "istanbul" || @Consensus == "qibft" -%>
+         <%- elsif @Consensus == "istanbul" || @Consensus == "qbft" -%>
            args=\" --gcmode archive --istanbul.blockperiod 3 --syncmode full --mine --minerthreads 1 \";
            RPC_APIS=\"$RPC_APIS,istanbul\";
          <%- elsif @Consensus == "clique" -%>
@@ -319,7 +319,7 @@ spec:
           mountPath: <%= @Node_DataDir%>/permission-nodes
         - name: geth-helpers
           mountPath: /geth-helpers
-        <%- if @Consensus == "istanbul" || @Consensus == "qibft" -%>
+        <%- if @Consensus == "istanbul" || @Consensus == "qbft" -%>
         - name: istanbul-validator-config
           mountPath: <%= @Node_DataDir%>/istanbul-validator-config.toml
         - name: node-management
@@ -395,7 +395,7 @@ spec:
             - key: geth-exec.sh
               path: geth-exec.sh
           defaultMode: 0777
-      <%- if @Consensus == "istanbul" || @Consensus == "qibft" -%>
+      <%- if @Consensus == "istanbul" || @Consensus == "qbft" -%>
       - name: istanbul-validator-config
         configMap:
           name: istanbul-validator-config.toml

--- a/templates/k8s/quorum-keystore.yaml.erb
+++ b/templates/k8s/quorum-keystore.yaml.erb
@@ -48,7 +48,7 @@ data:
 <% end -%>
 
 # Only IBFT / istanbul networks need access to the nodekey address.
-<%- if (@Consensus == "istanbul" || @Consensus == "qibft") && File.file?("#{@Key_Dir_Base}/#{@Node_Key_Dir}/nodekeyaddress") -%>
+<%- if (@Consensus == "istanbul" || @Consensus == "qbft") && File.file?("#{@Key_Dir_Base}/#{@Node_Key_Dir}/nodekeyaddress") -%>
 ---
 # nodekey address public and used to generate istanbul-validator-config.toml
 apiVersion: v1

--- a/templates/k8s/quorum-shared-config.yaml.erb
+++ b/templates/k8s/quorum-shared-config.yaml.erb
@@ -89,7 +89,7 @@ data:
     <% end -%>
 <%- end -%>
 ## include ibft helpers as we don't know which nodes will be running which consensus.
-<%- if @config["genesis"]["consensus"] == "istanbul" || @config["genesis"]["consensus"] == "qibft" -%>
+<%- if @config["genesis"]["consensus"] == "istanbul" || @config["genesis"]["consensus"] == "qbft" -%>
 
 ---
 apiVersion: v1

--- a/templates/quorum/gen-keys.sh.erb
+++ b/templates/quorum/gen-keys.sh.erb
@@ -49,7 +49,7 @@ for node_key_dir in "${array[@]}"; do
     bootnode -genkey nodekey
     bootnode  -nodekeyhex $(cat nodekey) -writeaddress > enode
     # Only IBFT / istanbul networks need access to the nodekey address.
-<%- if @Consensus == "istanbul" || @Consensus == "qibft" -%>
+<%- if @Consensus == "istanbul" || @Consensus == "qbft" -%>
     # save nodekey address (used for istanbul-validator-config.toml)
     ethkey generate nodekeyacct.json --passwordfile password.txt --privatekey nodekey | sed 's/Address: //g' | sed 's/}//g' > nodekeyaddress
 <%- end -%>

--- a/templates/quorum/genesis.json.erb
+++ b/templates/quorum/genesis.json.erb
@@ -11,10 +11,10 @@ if @config["genesis"] and @config["genesis"]["Chain_Id"]
 end
 ## The genesis consensus and the quorum version must be set in the config file.
 @Genesis_Consensus = @config["genesis"]["consensus"]
-# if the qibftblock is set, the network will switch over to qibft consensus
+# if the testqbftblock is set, the network will switch over to qbft consensus
 # when the specified block number is reached.
-if @config["genesis"]["qibftBlock"]
-  @Qibft_Block = @config["genesis"]["qibftBlock"]
+if @config["genesis"]["Test_QBFT_Block"]
+  @Test_QBFT_Block = @config["genesis"]["Test_QBFT_Block"]
 end
 @Genesis_Quorum_Version = @config["genesis"]["Quorum_Version"]
 @Genesis_Tm_Version = @config["genesis"]["Tm_Version"]
@@ -105,14 +105,15 @@ end
   "parenthash": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "timestamp": "0x00"
 }
-<%- elsif @Genesis_Consensus == "istanbul" ||  @Genesis_Consensus == "qibft" -%>
+<%- elsif @Genesis_Consensus == "istanbul" ||  @Genesis_Consensus == "qbft" -%>
     "isQuorum": true,
     "istanbul": {
-      <%- if @Qibft_Block -%>
-      "qibftBlock": <%= @Qibft_Block %>,
+      <%- if @Genesis_Consensus == "qbft" && @Test_QBFT_Block -%>
+      "testQBFTBlock": <%= @Test_QBFT_Block %>,
       <%- end -%>
       "epoch": 30000,
-      "policy": 0
+      "policy": 0,
+      "ceil2Nby3Block": 0
     }
   },
 
@@ -130,8 +131,16 @@ end
    # To do this, we need to create the istanbul-validator-config.toml from the ethereum nodekey. The istanbul-validator-config.toml
    # is then given as input to the istanbul tool, which will calculate the necessary extradata field.
   %>
+  <%- if @Genesis_Consensus == "istanbul" -%>
+    <%-
+       extraData=`istanbul extra encode --config #{@Istanbul_Validator_Config} | awk '{print $4}'`
+    -%>
+  <%- else -%>
+    <%-
+       extraData=`qbft extra encode --config #{@Istanbul_Validator_Config} | awk '{print $4}'`
+    -%>
+  <%- end -%>
   <%-
-   extraData=`istanbul extra encode --config #{@Istanbul_Validator_Config} | awk '{print $4}'`
    extraData=extraData.strip
    puts("Generated istanbul \"extraData\"=\"" + extraData + "\"")
    -%>

--- a/testing/qversions-config/qubes-qbft-21.7.1-tessera-21.7.2.yaml
+++ b/testing/qversions-config/qubes-qbft-21.7.1-tessera-21.7.2.yaml
@@ -1,0 +1,72 @@
+# ./quick-start-gen --chain-id=1000   --tm-name=tessera --num-nodes=3 --geth-statrup-params=--rpccorsdomain="*" --consensus=qbft --quorum-version=21.7.1  --tm-version=21.7.2
+genesis:
+  # supported: (raft | istanbul)
+  consensus: qbft
+  Quorum_Version: 21.7.1
+  Tm_Version: 21.7.2
+  Chain_Id: 1000
+  Test_QBFT_Block: 0
+
+
+# Add as many nodes as you wish below
+# Note:  keys should be set locally.
+nodes:
+    
+  -  Node_UserIdent: quorum-node1
+     Key_Dir: key1
+     quorum:
+       quorum:
+         # supported: (raft | istanbul)
+         consensus: qbft
+         Quorum_Version: 21.7.1
+         Docker_Repo: 
+       tm:
+         # (tessera|constellation)
+         Name: tessera
+         Tm_Version: 21.7.2
+         Docker_Repo: 
+       geth:
+         network:
+           id: 1000
+         verbosity: 9
+         Geth_Startup_Params: --rpccorsdomain=*
+    
+  -  Node_UserIdent: quorum-node2
+     Key_Dir: key2
+     quorum:
+       quorum:
+         # supported: (raft | istanbul)
+         consensus: qbft
+         Quorum_Version: 21.7.1
+         Docker_Repo: 
+       tm:
+         # (tessera|constellation)
+         Name: tessera
+         Tm_Version: 21.7.2
+         Docker_Repo: 
+       geth:
+         network:
+           id: 1000
+         verbosity: 9
+         Geth_Startup_Params: --rpccorsdomain=*
+    
+  -  Node_UserIdent: quorum-node3
+     Key_Dir: key3
+     quorum:
+       quorum:
+         # supported: (raft | istanbul)
+         consensus: qbft
+         Quorum_Version: 21.7.1
+         Docker_Repo: 
+       tm:
+         # (tessera|constellation)
+         Name: tessera
+         Tm_Version: 21.7.2
+         Docker_Repo: 
+       geth:
+         network:
+           id: 1000
+         verbosity: 9
+         Geth_Startup_Params: --rpccorsdomain=*
+    
+


### PR DESCRIPTION
`qbft` fork block has been updated to `testQBFTBlock`. `qctl` and `quick-start` has been updated to reflect the same. Also, `qbft` now uses `qbft` binary from `istanbul-tools` to encode validators